### PR TITLE
Feature/man du2001/match request and wait

### DIFF
--- a/src/main/java/com/shootdoori/match/entity/Match.java
+++ b/src/main/java/com/shootdoori/match/entity/Match.java
@@ -1,0 +1,82 @@
+package com.shootdoori.match.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "match_table")
+public class Match {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "MATCH_ID")
+  private Integer matchId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "TEAM1_ID", nullable = false)
+  private Team team1;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "TEAM2_ID", nullable = false)
+  private Team team2;
+
+  @Column(name = "MATCH_DATE", nullable = false)
+  private LocalDate matchDate;
+
+  @Column(name = "MATCH_TIME", nullable = false)
+  private LocalTime matchTime;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "VENUE_ID", nullable = false)
+  private Venue venue;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "STATUS", nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '예정'")
+  private MatchStatus status = MatchStatus.모집중;
+
+  @Column(name = "CREATED_AT", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+  private LocalDateTime createdAt;
+
+  @Column(name = "UPDATED_AT", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+  private LocalDateTime updatedAt;
+
+  protected Match() {}
+
+  public Integer getMatchId() {
+    return matchId;
+  }
+
+  public Team getTeam1() {
+    return team1;
+  }
+
+  public Team getTeam2() {
+    return team2;
+  }
+
+  public LocalDate getMatchDate() {
+    return matchDate;
+  }
+
+  public LocalTime getMatchTime() {
+    return matchTime;
+  }
+
+  public Venue getVenue() {
+    return venue;
+  }
+
+  public MatchStatus getStatus() {
+    return status;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/src/main/java/com/shootdoori/match/entity/MatchRequest.java
+++ b/src/main/java/com/shootdoori/match/entity/MatchRequest.java
@@ -1,0 +1,72 @@
+package com.shootdoori.match.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "match_requests")
+public class MatchRequest {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "REQUEST_ID")
+  private Integer requestId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "REQUESTING_TEAM_ID", nullable = false)
+  private Team requestingTeam;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "TARGET_TEAM_ID", nullable = false)
+  private Team targetTeam;
+
+  @Column(name = "REQUEST_MESSAGE", columnDefinition = "TEXT")
+  private String requestMessage;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "STATUS", nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '대기중'")
+  private MatchRequestStatus status = MatchRequestStatus.대기중;
+
+  @Column(name = "REQUESTED_AT", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+  private LocalDateTime requestedAt;
+
+  @Column(name = "RESPONDED_AT")
+  private LocalDateTime respondedAt;
+
+  @Column(name = "UPDATED_AT", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+  private LocalDateTime updatedAt;
+
+  protected MatchRequest() {}
+
+  public Integer getRequestId() {
+    return requestId;
+  }
+
+  public Team getRequestingTeam() {
+    return requestingTeam;
+  }
+
+  public Team getTargetTeam() {
+    return targetTeam;
+  }
+
+  public String getRequestMessage() {
+    return requestMessage;
+  }
+
+  public MatchRequestStatus getMatchRequestStatus() {
+    return status;
+  }
+
+  public LocalDateTime getRequestedAt() {
+    return requestedAt;
+  }
+
+  public LocalDateTime getRespondedAt() {
+    return respondedAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/src/main/java/com/shootdoori/match/entity/MatchRequestStatus.java
+++ b/src/main/java/com/shootdoori/match/entity/MatchRequestStatus.java
@@ -1,0 +1,8 @@
+package com.shootdoori.match.entity;
+
+public enum MatchRequestStatus {
+  대기중,
+  수락,
+  거절,
+  취소
+}

--- a/src/main/java/com/shootdoori/match/entity/MatchStatus.java
+++ b/src/main/java/com/shootdoori/match/entity/MatchStatus.java
@@ -1,0 +1,8 @@
+package com.shootdoori.match.entity;
+
+public enum MatchStatus {
+  모집중,
+  매칭완료,
+  경기완료,
+  취소
+}

--- a/src/main/java/com/shootdoori/match/entity/MatchWaiting.java
+++ b/src/main/java/com/shootdoori/match/entity/MatchWaiting.java
@@ -1,0 +1,118 @@
+package com.shootdoori.match.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "match_waiting")
+public class MatchWaiting {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "WAITING_ID")
+  private Integer waitingId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "TEAM_ID", nullable = false)
+  private Team team;
+
+  @Column(name = "PREFERRED_DATE", nullable = false)
+  private LocalDate preferredDate;
+
+  @Column(name = "PREFERRED_TIME_START", nullable = false)
+  private LocalTime preferredTimeStart;
+
+  @Column(name = "PREFERRED_TIME_END", nullable = false)
+  private LocalTime preferredTimeEnd;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "PREFERRED_VENUE_ID", nullable = false)
+  private Venue preferredVenue;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "SKILL_LEVEL_MIN", nullable = false)
+  private SkillLevel skillLevelMin;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "SKILL_LEVEL_MAX", nullable = false)
+  private SkillLevel skillLevelMax;
+
+  @Column(name = "UNIVERSITY_ONLY", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+  private Boolean universityOnly = false;
+
+  @Column(name = "MESSAGE", columnDefinition = "TEXT")
+  private String message;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "STATUS", nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '대기중'")
+  private MatchWaitingStatus status = MatchWaitingStatus.대기중;
+
+  @Column(name = "EXPIRES_AT", nullable = false, columnDefinition = "TIMESTAMP DEFAULT (CURRENT_TIMESTAMP + INTERVAL '24' HOUR)")
+  private LocalDateTime expiresAt;
+
+  @Column(name = "CREATED_AT", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+  private LocalDateTime createdAt;
+
+  @Column(name = "UPDATED_AT", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+  private LocalDateTime updatedAt;
+
+  protected MatchWaiting() {}
+
+  public Integer getWaitingId() {
+    return waitingId;
+  }
+
+  public Team getTeam() {
+    return team;
+  }
+
+  public LocalDate getPreferredDate() {
+    return preferredDate;
+  }
+
+  public LocalTime getPreferredTimeStart() {
+    return preferredTimeStart;
+  }
+
+  public LocalTime getPreferredTimeEnd() {
+    return preferredTimeEnd;
+  }
+
+  public Venue getPreferredVenue() {
+    return preferredVenue;
+  }
+
+  public SkillLevel getSkillLevelMin() {
+    return skillLevelMin;
+  }
+
+  public SkillLevel getSkillLevelMax() {
+    return skillLevelMax;
+  }
+
+  public Boolean getUniversityOnly() {
+    return universityOnly;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public MatchWaitingStatus getMatchRequestStatus() {
+    return status;
+  }
+
+  public LocalDateTime getExpiresAt() {
+    return expiresAt;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/src/main/java/com/shootdoori/match/entity/MatchWaitingStatus.java
+++ b/src/main/java/com/shootdoori/match/entity/MatchWaitingStatus.java
@@ -1,0 +1,8 @@
+package com.shootdoori.match.entity;
+
+public enum MatchWaitingStatus {
+  대기중,
+  완료,
+  취소,
+  만료
+}

--- a/src/main/java/com/shootdoori/match/entity/SkillLevel.java
+++ b/src/main/java/com/shootdoori/match/entity/SkillLevel.java
@@ -1,0 +1,7 @@
+package com.shootdoori.match.entity;
+
+public enum SkillLevel {
+  프로,
+  세미프로,
+  아마추어
+}

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -1,0 +1,107 @@
+package com.shootdoori.match.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "teams")
+public class Team {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "TEAM_ID")
+  private Long teamId;
+
+  @Column(name = "TEAM_NAME", nullable = false, length = 100)
+  private String teamName;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "CAPTAIN_ID", nullable = false)
+  private User captain;
+
+  @Column(name = "UNIVERSITY", nullable = false, length = 100)
+  private String university;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "TEAM_TYPE", nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '동아리'")
+  private TeamType teamType = TeamType.기타;
+
+  @Column(name = "MEMBER_COUNT", nullable = false, columnDefinition = "INT DEFAULT 0")
+  private Integer memberCount = 0;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "SKILL_LEVEL", nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '아마추어'")
+  private SkillLevel skillLevel = SkillLevel.아마추어;
+
+  @Column(name = "DESCRIPTION", length = 1000)
+  private String description;
+
+  @Column(name = "CREATED_AT", updatable = false)
+  private LocalDateTime createdAt = LocalDateTime.now();
+
+  @Column(name = "UPDATED_AT")
+  private LocalDateTime updatedAt = LocalDateTime.now();
+
+  protected Team() {}
+
+  public Team(String teamName, User captain, String university, TeamType teamType,
+      Integer memberCount, SkillLevel skillLevel, String description) {
+    this.teamName = teamName;
+    this.captain = captain;
+    this.university = university;
+    this.teamType = teamType != null ? teamType : TeamType.기타;
+    this.memberCount = memberCount != null ? memberCount : 0;
+    this.skillLevel = skillLevel != null ? skillLevel : SkillLevel.아마추어;
+    this.description = description;
+  }
+
+  public Long getTeamId() {
+    return teamId;
+  }
+
+  public String getTeamName() {
+    return teamName;
+  }
+
+  public User getCaptain() {
+    return captain;
+  }
+
+  public String getUniversity() {
+    return university;
+  }
+
+  public TeamType getTeamType() {
+    return teamType;
+  }
+
+  public Integer getMemberCount() {
+    return memberCount;
+  }
+
+  public SkillLevel getSkillLevel() {
+    return skillLevel;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/src/main/java/com/shootdoori/match/entity/TeamType.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamType.java
@@ -1,0 +1,7 @@
+package com.shootdoori.match.entity;
+
+public enum TeamType {
+  중앙동아리,
+  과동아리,
+  기타
+}

--- a/src/main/java/com/shootdoori/match/entity/User.java
+++ b/src/main/java/com/shootdoori/match/entity/User.java
@@ -1,0 +1,128 @@
+package com.shootdoori.match.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(
+    name = "users",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = "email"),
+        @UniqueConstraint(columnNames = "universityEmail")
+    }
+)
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long userId;
+
+  @Column(nullable = false, length = 255)
+  private String email;
+
+  @Column(nullable = false, length = 255)
+  private String universityEmail;
+
+  @Column(nullable = false, length = 255)
+  private String password;
+
+  @Column(nullable = false, length = 100)
+  private String name;
+
+  @Column(nullable = false, length = 20)
+  private String phoneNumber;
+
+  @Column(nullable = false, length = 100)
+  private String university;
+
+  @Column(nullable = false, length = 100)
+  private String department;
+
+  @Column(nullable = false, length = 2)
+  private String studentYear;
+
+  @Column(columnDefinition = "TEXT")
+  private String bio;
+
+  @CreationTimestamp
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  private LocalDateTime updatedAt;
+
+  protected User() {}
+
+  public User(Long userId, String email, String universityEmail, String password,
+      String name, String phoneNumber, String university, String department,
+      String studentYear, String bio, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    this.userId = userId;
+    this.email = email;
+    this.universityEmail = universityEmail;
+    this.password = password;
+    this.name = name;
+    this.phoneNumber = phoneNumber;
+    this.university = university;
+    this.department = department;
+    this.studentYear = studentYear;
+    this.bio = bio;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getUniversityEmail() {
+    return universityEmail;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getPhoneNumber() {
+    return phoneNumber;
+  }
+
+  public String getUniversity() {
+    return university;
+  }
+
+  public String getDepartment() {
+    return department;
+  }
+
+  public String getStudentYear() {
+    return studentYear;
+  }
+
+  public String getBio() {
+    return bio;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/src/main/java/com/shootdoori/match/entity/Venue.java
+++ b/src/main/java/com/shootdoori/match/entity/Venue.java
@@ -1,0 +1,89 @@
+package com.shootdoori.match.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "venues")
+public class Venue {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "VENUE_ID")
+  private Integer venueId;
+
+  @Column(name = "VENUE_NAME", nullable = false, length = 100)
+  private String venueName;
+
+  @Column(name = "ADDRESS", nullable = false, length = 255)
+  private String address;
+
+  @Column(name = "LATITUDE", nullable = false, precision = 10, scale = 8)
+  private BigDecimal latitude;
+
+  @Column(name = "LONGITUDE", nullable = false, precision = 11, scale = 8)
+  private BigDecimal longitude;
+
+  @Column(name = "CONTACT_INFO", length = 100)
+  private String contactInfo;
+
+  @Column(name = "FACILITIES", columnDefinition = "TEXT")
+  private String facilities;
+
+  @Column(name = "PRICE_PER_HOUR")
+  private Integer pricePerHour;
+
+  @Column(name = "CREATED_AT", updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+  private LocalDateTime createdAt;
+
+  @Column(name = "UPDATED_AT", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+  private LocalDateTime updatedAt;
+
+  protected Venue() {}
+
+  public Integer getVenueId() {
+    return venueId;
+  }
+
+  public String getVenueName() {
+    return venueName;
+  }
+
+  public String getAddress() {
+    return address;
+  }
+
+  public BigDecimal getLatitude() {
+    return latitude;
+  }
+
+  public BigDecimal getLongitude() {
+    return longitude;
+  }
+
+  public String getContactInfo() {
+    return contactInfo;
+  }
+
+  public String getFacilities() {
+    return facilities;
+  }
+
+  public Integer getPricePerHour() {
+    return pricePerHour;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/src/main/java/com/shootdoori/match/repository/MatchRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/MatchRepository.java
@@ -1,0 +1,19 @@
+package com.shootdoori.match.repository;
+
+import com.shootdoori.match.entity.Match;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MatchRepository extends JpaRepository<Match, Long> {
+
+  @Query("SELECT m FROM Match m " +
+      "WHERE (m.team1.teamId = :teamId OR m.team2.teamId = :teamId) " +
+      "AND m.status = '경기완료' " +
+      "ORDER BY m.matchDate DESC, m.matchTime DESC")
+  Page<Match> findCompletedMatchesByTeamId(@Param("teamId") Long teamId, Pageable pageable);
+}

--- a/src/main/java/com/shootdoori/match/repository/MatchRequestRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/MatchRequestRepository.java
@@ -1,0 +1,20 @@
+package com.shootdoori.match.repository;
+
+import com.shootdoori.match.entity.MatchRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MatchRequestRepository extends JpaRepository<MatchRequest, Integer> {
+
+  @Modifying
+  @Query("UPDATE MatchRequest mr " +
+      "SET mr.status = '거절' " +
+      "WHERE mr.targetTeam.teamId = :targetTeamId " +
+      "AND mr.status = '대기중' " +
+      "AND mr.requestId <> :acceptedRequestId")
+  int rejectOtherRequests(@Param("targetTeamId") Long targetTeamId,
+      @Param("acceptedRequestId") Integer acceptedRequestId);
+
+}

--- a/src/main/java/com/shootdoori/match/repository/MatchWaitingRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/MatchWaitingRepository.java
@@ -1,0 +1,24 @@
+package com.shootdoori.match.repository;
+
+import com.shootdoori.match.entity.MatchWaiting;
+import java.time.LocalDate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MatchWaitingRepository extends JpaRepository<MatchWaiting, Long> {
+  @Query("SELECT mw FROM MatchWaiting mw " +
+      "WHERE mw.preferredDate = :date " +
+      "AND mw.status = '대기중' " +
+      "AND mw.team.id <> :teamId " + //우리 팀 제외
+      "ORDER BY mw.preferredTimeStart ASC")
+  Page<MatchWaiting> findAvailableMatchesByDate(
+      @Param("date") LocalDate date,
+      @Param("teamId") Long teamId,
+      Pageable pageable);
+}
+


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
X
---

## 🛠️ 뭘 했는지
매칭 요청 후 대기 서비스 구현을 위한,

[1]
필요 Entity 정의 (당장 필요하지 않은 "팀 멤버",  "팀 리뷰", "용병 리뷰" entity는 정의 하지 않음)

[2]
추후 기능 테스트에 필수적인 JPA Repository 정의 
(매치 요청, 대기, 성사에 관한 3가지만)

팀 생성 이후부터 매치 성사 이전까지의 와이어 프레임 상으로 필요한
JPA repository custom method 생성 했으며, 아래에 각각 설명

[MatchWaitingRepository 의 findAvailableMatchesByDate]
참여 가능한 매치 목록을 
원하는 날짜, status 대기중, 우리팀은 제외하며, 오름차순으로 조회하는 메소드

[MatchRequestRepository 의 rejectOtherRequests]
한 팀의 경기를 수락시, 나머지 대기중인 팀들에 대해 일괄적으로 거절 상태로 변경하는 메소드

[MatchRepository의 findCompletedMatchesByTeamId]
이제까지 우리팀이 경기한 매치 목록을 최신순(날짜 기준 내림차순)으로 
페이징 적용한 메소드


---

## 📷 스크린샷
X
---

## ✅ 확인 사항
- [ ] 로컬에서 잘 돌아감 
=> 일단, repository 까지만 구현해서 테스트는 못했지만, 
기능이 아직까진 단순하고, PR 올리기 위해 작성한 부분까지만 올렸어요
추후 dto, service, controller 구현후 로컬에서 postman이용하여 테스트할 예정입니다.

- [V] 기존 기능 안 망가뜨림
- [V] 코드 정리함

---

## 👀 특히 봐주세요!
커스텀 메소드 query 보완할 점, 이상한 점
프론트에서 필요할 것 같은 메소드 등 지적해주세요.
---

*PR 확인 부탁드려요! 🙏*