### PR TITLE
feat(profile): 마이페이지(사용자 프로필) CRUD API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,11 @@ repositories {
 
 dependencies {
 // 초기 세팅이므로 DB 관련 의존성은 주석처리
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-//	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/shootdoori/match/controller/ProfileController.java
+++ b/src/main/java/com/shootdoori/match/controller/ProfileController.java
@@ -1,0 +1,41 @@
+package com.shootdoori.match.controller;
+
+import com.shootdoori.match.dto.ProfileCreateRequest;
+import com.shootdoori.match.dto.ProfileResponse;
+import com.shootdoori.match.dto.ProfileUpdateRequest;
+import com.shootdoori.match.service.ProfileService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/profiles")
+public class ProfileController {
+    private final ProfileService profileService;
+
+    public ProfileController(ProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ProfileResponse> postProfile(@RequestBody ProfileCreateRequest request) {
+        return new ResponseEntity<>(profileService.createProfile(request), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateProfile(@PathVariable Long id, @RequestBody ProfileUpdateRequest request) {
+        profileService.updateProfile(id, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProfileResponse> getProfile(@PathVariable Long id) {
+        return new ResponseEntity<>(profileService.findProfileById(id), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteProfile(@PathVariable Long id) {
+        profileService.deleteProfile(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/shootdoori/match/controller/ProfileController.java
+++ b/src/main/java/com/shootdoori/match/controller/ProfileController.java
@@ -4,6 +4,7 @@ import com.shootdoori.match.dto.ProfileCreateRequest;
 import com.shootdoori.match.dto.ProfileResponse;
 import com.shootdoori.match.dto.ProfileUpdateRequest;
 import com.shootdoori.match.service.ProfileService;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,12 +19,12 @@ public class ProfileController {
     }
 
     @PostMapping
-    public ResponseEntity<ProfileResponse> postProfile(@RequestBody ProfileCreateRequest request) {
+    public ResponseEntity<ProfileResponse> postProfile(@Valid @RequestBody ProfileCreateRequest request) {
         return new ResponseEntity<>(profileService.createProfile(request), HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Void> updateProfile(@PathVariable Long id, @RequestBody ProfileUpdateRequest request) {
+    public ResponseEntity<Void> updateProfile(@PathVariable Long id, @Valid @RequestBody ProfileUpdateRequest request) {
         profileService.updateProfile(id, request);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/shootdoori/match/dto/ProfileCreateRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileCreateRequest.java
@@ -1,13 +1,42 @@
 package com.shootdoori.match.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 public record ProfileCreateRequest(
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    @Size(min = 2, max = 100, message = "이름은 2자 이상 100자 이하로 입력해주세요.")
     String name,
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @Size(max = 255, message = "이메일 주소는 255자를 초과할 수 없습니다.")
     String email,
+
+    @NotBlank(message = "학교 이메일은 필수 입력 값입니다.")
+    @Email(message = "학교 이메일 형식이 올바르지 않습니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@([a-zA-Z0-9-]+\\.)*ac\\.kr$", message = "학교 이메일은 'ac.kr' 도메인이어야 합니다.")
+    @Size(max = 255, message = "학교 이메일 주소는 255자를 초과할 수 없습니다.")
     String universityEmail,
+
+    @NotBlank(message = "핸드폰 번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "핸드폰 번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
     String phoneNumber,
+
+    @NotBlank(message = "대학교 이름은 필수 입력 값입니다.")
+    @Size(max = 100, message = "대학교 이름은 100자를 초과할 수 없습니다.")
     String university,
+
+    @NotBlank(message = "학과 이름은 필수 입력 값입니다.")
+    @Size(max = 100, message = "학과 이름은 100자를 초과할 수 없습니다.")
     String department,
+
+    @NotBlank(message = "학번은 필수 입력 값입니다.")
     String studentYear,
+
+    @Size(max = 500, message = "자기소개는 500자를 초과할 수 없습니다.")
     String bio
 ) {
 }

--- a/src/main/java/com/shootdoori/match/dto/ProfileCreateRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileCreateRequest.java
@@ -1,0 +1,13 @@
+package com.shootdoori.match.dto;
+
+public record ProfileCreateRequest(
+    String name,
+    String email,
+    String universityEmail,
+    String phoneNumber,
+    String university,
+    String department,
+    String studentYear,
+    String bio
+) {
+}

--- a/src/main/java/com/shootdoori/match/dto/ProfileMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileMapper.java
@@ -1,0 +1,19 @@
+package com.shootdoori.match.dto;
+
+import com.shootdoori.match.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProfileMapper {
+    public ProfileResponse toProfileResponse(User user) {
+        if (user == null) {
+            return null;
+        }
+
+        return new ProfileResponse(
+            user.getName(),
+            user.getUniversity(),
+            user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/shootdoori/match/dto/ProfileRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileRequest.java
@@ -1,0 +1,4 @@
+package com.shootdoori.match.dto;
+
+public record ProfileRequest(Long id) {
+}

--- a/src/main/java/com/shootdoori/match/dto/ProfileResponse.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileResponse.java
@@ -1,0 +1,10 @@
+package com.shootdoori.match.dto;
+
+import java.time.LocalDateTime;
+
+public record ProfileResponse(
+    String name,
+    String university,
+    LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/shootdoori/match/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileUpdateRequest.java
@@ -1,4 +1,9 @@
 package com.shootdoori.match.dto;
 
-public record ProfileUpdateRequest(String name) {
+import jakarta.validation.constraints.Size;
+
+public record ProfileUpdateRequest(
+    @Size(min = 2, max = 100, message = "이름은 2자 이상 100자 이하로 입력해주세요.")
+    String name
+) {
 }

--- a/src/main/java/com/shootdoori/match/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.shootdoori.match.dto;
+
+public record ProfileUpdateRequest(String name) {
+}

--- a/src/main/java/com/shootdoori/match/entity/User.java
+++ b/src/main/java/com/shootdoori/match/entity/User.java
@@ -1,0 +1,110 @@
+package com.shootdoori.match.entity;
+
+import com.shootdoori.match.dto.ProfileCreateRequest;
+import com.shootdoori.match.dto.ProfileUpdateRequest;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "university_email",nullable = false, unique = true)
+    private String universityEmail;
+
+    @Column(name = "phone_number",nullable = false, unique = true)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private String university;
+
+    @Column(nullable = false)
+    private String department;
+
+    @Column(name = "student_year",nullable = false)
+    private String studentYear;
+
+    private String bio;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    protected User() {
+
+    }
+
+    public User(ProfileCreateRequest createRequest) {
+        this.name = createRequest.name();
+        this.email = createRequest.email();
+        this.universityEmail = createRequest.universityEmail();
+        this.phoneNumber = createRequest.phoneNumber();
+        this.university = createRequest.university();
+        this.department = createRequest.department();
+        this.studentYear = createRequest.studentYear();
+        this.bio = createRequest.bio();
+    }
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getEmail() {
+        return this.email;
+    }
+
+    public String getUniversityEmail() {
+        return this.universityEmail;
+    }
+
+    public String getPhoneNumber() {
+        return this.phoneNumber;
+    }
+
+    public String getUniversity() {
+        return this.university;
+    }
+
+    public String getDepartment() {
+        return this.department;
+    }
+
+    public String getStudentYear() {
+        return this.studentYear;
+    }
+
+    public String getBio() {
+        return this.bio;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return this.createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return this.updatedAt;
+    }
+
+    public void update(ProfileUpdateRequest updateRequest) {
+        this.name = updateRequest.name();
+    }
+}

--- a/src/main/java/com/shootdoori/match/exception/DuplicatedDataException.java
+++ b/src/main/java/com/shootdoori/match/exception/DuplicatedDataException.java
@@ -1,0 +1,11 @@
+package com.shootdoori.match.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class DuplicatedDataException extends RuntimeException {
+    public DuplicatedDataException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/shootdoori/match/repository/ProfileRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/ProfileRepository.java
@@ -4,4 +4,5 @@ import com.shootdoori.match.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProfileRepository extends JpaRepository<User, Long> {
+    boolean existsByEmailOrUniversityEmail(String email, String universityEmail);
 }

--- a/src/main/java/com/shootdoori/match/repository/ProfileRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/ProfileRepository.java
@@ -1,0 +1,7 @@
+package com.shootdoori.match.repository;
+
+import com.shootdoori.match.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProfileRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/shootdoori/match/service/ProfileService.java
+++ b/src/main/java/com/shootdoori/match/service/ProfileService.java
@@ -2,6 +2,7 @@ package com.shootdoori.match.service;
 
 import com.shootdoori.match.dto.*;
 import com.shootdoori.match.entity.User;
+import com.shootdoori.match.exception.DuplicatedDataException;
 import com.shootdoori.match.repository.ProfileRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,11 @@ public class ProfileService {
      * @return 생성된 프로필 정보가 담긴 응답 DTO
      */
     public ProfileResponse createProfile(ProfileCreateRequest createRequest) {
+        if (profileRepository.existsByEmailOrUniversityEmail(
+            createRequest.email(), createRequest.universityEmail())
+        ) {
+            throw new DuplicatedDataException("이미 존재하는 사용자입니다.");
+        }
         User saveProfile = profileRepository.save(new User(createRequest));
         return profileMapper.toProfileResponse(saveProfile);
     }

--- a/src/main/java/com/shootdoori/match/service/ProfileService.java
+++ b/src/main/java/com/shootdoori/match/service/ProfileService.java
@@ -1,0 +1,64 @@
+package com.shootdoori.match.service;
+
+import com.shootdoori.match.dto.*;
+import com.shootdoori.match.entity.User;
+import com.shootdoori.match.repository.ProfileRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ProfileService {
+    private final ProfileRepository profileRepository;
+    private final ProfileMapper profileMapper;
+
+    public ProfileService(ProfileRepository profileRepository, ProfileMapper profileMapper) {
+        this.profileRepository = profileRepository;
+        this.profileMapper = profileMapper;
+    }
+
+    /**
+     * 새로운 프로필를 생성하고 데이터베이스에 저장합니다.
+     * @param createRequest 프로필 생성을 위한 데이터가 담긴 DTO
+     * @return 생성된 프로필 정보가 담긴 응답 DTO
+     */
+    public ProfileResponse createProfile(ProfileCreateRequest createRequest) {
+        User saveProfile = profileRepository.save(new User(createRequest));
+        return profileMapper.toProfileResponse(saveProfile);
+    }
+
+    /**
+     * ID를 이용해 특정 프로필을 조회합니다.
+     * @param id 조회할 프로필의 ID
+     * @return 조회된 프로필 정보가 담긴 응답 DTO
+     * @throws IllegalArgumentException 해당 ID의 프로필이 존재하지 않을 경우 발생
+     */
+    @Transactional(readOnly = true)
+    public ProfileResponse findProfileById(Long id) {
+        User profile = profileRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 프로필을 찾을 수 없습니다."));
+        return profileMapper.toProfileResponse(profile);
+    }
+
+    /**
+     * 기존 프로필의 정보를 수정합니다.
+     * @param id 수정할 프로필의 ID
+     * @param updateRequest 수정할 정보가 담긴 DTO
+     * @throws IllegalArgumentException 해당 ID의 프로필이 존재하지 않을 경우 발생
+     */
+    public void updateProfile(Long id, ProfileUpdateRequest updateRequest) {
+        User profile = profileRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 프로필을 찾을 수 없습니다."));
+        profile.update(updateRequest);
+    }
+
+    /**
+     * ID를 이용해 특정 프로필을 삭제합니다.
+     * @param id 삭제할 프로필의 ID
+     * @throws IllegalArgumentException 해당 ID의 프로필이 존재하지 않을 경우 발생
+     */
+    public void deleteProfile(Long id) {
+        if (!profileRepository.existsById(id)) {
+            throw new IllegalArgumentException("해당 프로필이 존재하지 않습니다.");
+        }
+        profileRepository.deleteById(id);
+    }
+}

--- a/src/test/java/com/shootdoori/profile/ProfileTest.java
+++ b/src/test/java/com/shootdoori/profile/ProfileTest.java
@@ -1,0 +1,82 @@
+package com.shootdoori.profile;
+
+import com.shootdoori.match.dto.ProfileCreateRequest;
+import com.shootdoori.match.dto.ProfileUpdateRequest;
+import com.shootdoori.match.entity.User;
+import com.shootdoori.match.exception.DuplicatedDataException;
+import com.shootdoori.match.repository.ProfileRepository;
+import com.shootdoori.match.service.ProfileService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ProfileTest {
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @InjectMocks
+    private ProfileService profileService;
+
+    @Test
+    @DisplayName("프로필 정보 수정 성공")
+    void updateProfile_Success() {
+        // given
+        Long userId = 1L;
+        ProfileCreateRequest createRequest = new ProfileCreateRequest(
+            "jam",
+            "test@email.com",
+            "test@email.co.kr",
+            "010-0000-0000",
+            "knu",
+            "cs",
+            "202500000",
+            "hello, world"
+        );
+        User user = new User(createRequest);
+        ProfileUpdateRequest updateRequest = new ProfileUpdateRequest("변경된이름");
+
+        when(profileRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // when
+        profileService.updateProfile(userId, updateRequest);
+
+        // then
+        assertThat(user.getName()).isEqualTo("변경된이름");
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 이메일로 프로필 생성 시 DuplicatedDataException 예외 발생")
+    void createProfile_WithDuplicateEmail_ThrowsException() {
+        // given
+        ProfileCreateRequest createRequest = new ProfileCreateRequest(
+            "jam",
+            "duplicate@email.com",
+            "test@email.co.kr",
+            "010-0000-0000",
+            "knu",
+            "cs",
+            "202500000",
+            "hello, world"
+        );
+
+        when(profileRepository.existsByEmailOrUniversityEmail(
+            createRequest.email(),
+            createRequest.universityEmail()
+        )).thenReturn(true);
+
+        // when & then
+        assertThrows(DuplicatedDataException.class, () -> {
+            profileService.createProfile(createRequest);
+        });
+    }
+}


### PR DESCRIPTION
# 🔥 Pull Request
---

## 🛠️ 뭘 했는지
- User Entity 정의
- 마이페이지(사용자 프로필) CRUD API 엔드포인트 구현
  - POST /api/profiles: 프로필 생성 (201)
  - GET /api/profiles/{id}: 프로필 조회 (200)
  - PUT /api/profiles/{id}: 프로필 수정 (204)
  - DELETE /api/profiles/{id}: 프로필 삭제 (204)
- 프로필 생성, 수정 시 유효성 검증 추가
- 서비스 레이어에서 Response 반환 시 mapper 적용
---

## ✅ 확인 사항
- [V] 로컬에서 잘 돌아감
- [V] 기존 기능 안 망가뜨림
- [V] 코드 정리함
- [V] 테스트 코드 작성
  - 프로필 정보 수정 성공
  - 이미 존재하는 이메일로 프로필 생성 시 예외 발생
---

## 👀 특히 봐주세요!
- `update` 할 때 service에서 void를 반환하고 클라이언트에게 204가 응답하도록 작성했는데 바뀐 내용을 반환하고 200을 응답하는 게 좋을지 아니면 204를 응답하는 게 좋을지 잘 모르겠습니다.
- 조회, 수정, 삭제 로직에서 해당 id가 존재하는지 검사하고 없으면 예외를 발생시키는 부분이 있습니다. 지금 직접 서비스 레이어에 illegalargumentexception으로 작성되어있는데, 커스텀 예외를 만들 생각입니다. findById와 existsById의 return 값은 다르긴 하지만 값이 있는지 없는지 알 수 있는 건 비슷하다고 생각하는데 이런 경우 같은 예외로 묶어도 될까요?

---

*PR 확인 부탁드려요! 🙏*