### PR TITLE
Feature/sweet mine/match complete service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
 // 초기 세팅이므로 DB 관련 의존성은 주석처리
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/shootdoori/match/controller/MatchCompleteController.java
+++ b/src/main/java/com/shootdoori/match/controller/MatchCompleteController.java
@@ -5,9 +5,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/v1/matches")
 public class MatchCompleteController {
     private final MatchCompleteService matchCompleteService;
 
@@ -15,7 +17,8 @@ public class MatchCompleteController {
         this.matchCompleteService = matchCompleteService;
     }
 
-    @GetMapping
+
+    @GetMapping("/enemyTeam")
     public TeamResponseDto getEnemyTeam(@RequestBody MatchTeamRequestDto matchTeamDto) {
         return new ResponseEntity<>(matchCompleteService.getEnemyTeam(matchTeamDto), HttpStatus.OK);
     }

--- a/src/main/java/com/shootdoori/match/controller/MatchCompleteController.java
+++ b/src/main/java/com/shootdoori/match/controller/MatchCompleteController.java
@@ -18,6 +18,11 @@ public class MatchCompleteController {
     }
 
 
+    /**
+     * 특정 매치의 상대팀 정보 조회
+     * @param matchTeamDto 매치 id, 내 팀 id
+     * @return TeamResponseDto JSON
+     */
     @GetMapping("/enemyTeam")
     public TeamResponseDto getEnemyTeam(@RequestBody MatchTeamRequestDto matchTeamDto) {
         return new ResponseEntity<>(matchCompleteService.getEnemyTeam(matchTeamDto), HttpStatus.OK);

--- a/src/main/java/com/shootdoori/match/controller/MatchCompleteController.java
+++ b/src/main/java/com/shootdoori/match/controller/MatchCompleteController.java
@@ -1,0 +1,22 @@
+package com.shootdoori.match.controller;
+import com.shootdoori.match.dto.MatchTeamRequestDto;
+import com.shootdoori.match.service.MatchCompleteService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MatchCompleteController {
+    private final MatchCompleteService matchCompleteService;
+
+    public MatchCompleteController(MatchCompleteService matchCompleteService) {
+        this.matchCompleteService = matchCompleteService;
+    }
+
+    @GetMapping
+    public TeamResponseDto getEnemyTeam(@RequestBody MatchTeamRequestDto matchTeamDto) {
+        return new ResponseEntity<>(matchCompleteService.getEnemyTeam(matchTeamDto), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/shootdoori/match/dto/MatchTeamRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/MatchTeamRequestDto.java
@@ -1,0 +1,4 @@
+package com.shootdoori.match.dto;
+
+public record MatchTeamRequestDto(int matchId, int teamId) {
+}

--- a/src/main/java/com/shootdoori/match/service/MatchCompleteService.java
+++ b/src/main/java/com/shootdoori/match/service/MatchCompleteService.java
@@ -13,7 +13,12 @@ public class MatchCompleteService {
         this.matchRepository = matchRepository;
     }
 
-    public MatchTeamRequestDto getEnemyTeam(MatchTeamRequestDto matchTeamRequestDto) {
+    /**
+     * 매치 정보 조회 후 상대 팀 정보 조회하는 서비스
+     * @param matchTeamRequestDto 매치 id, 내 팀 id
+     * @return TeamResponseDto 적 팀 정보
+     */
+    public TeamResponseDto getEnemyTeam(MatchTeamRequestDto matchTeamRequestDto) {
         int enemyTeamId;
         Match match = matchRepository.findByMatchId(matchTeamRequestDto.matchId());
 

--- a/src/main/java/com/shootdoori/match/service/MatchCompleteService.java
+++ b/src/main/java/com/shootdoori/match/service/MatchCompleteService.java
@@ -1,0 +1,18 @@
+package com.shootdoori.match.service;
+
+import com.shootdoori.match.dto.MatchTeamRequestDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MatchCompleteService {
+    private TeamRepository teamRepository;
+    private MatchRepository matchRepository;
+
+    public MatchCompleteService(TeamRepository teamRepository, MatchRepository matchRepository){
+        this.teamRepository = teamRepository;
+        this.matchRepository = matchRepository;
+    }
+
+    public MatchTeamRequestDto getEnemyTeam(MatchTeamRequestDto) {
+    }
+}

--- a/src/main/java/com/shootdoori/match/service/MatchCompleteService.java
+++ b/src/main/java/com/shootdoori/match/service/MatchCompleteService.java
@@ -13,6 +13,18 @@ public class MatchCompleteService {
         this.matchRepository = matchRepository;
     }
 
-    public MatchTeamRequestDto getEnemyTeam(MatchTeamRequestDto) {
+    public MatchTeamRequestDto getEnemyTeam(MatchTeamRequestDto matchTeamRequestDto) {
+        int enemyTeamId;
+        Match match = matchRepository.findByMatchId(matchTeamRequestDto.matchId());
+
+        if(match.team1Id == matchTeamRequestDto.teamId()){
+            enemyTeamId = match.team2Id;
+        }
+        else {
+            enemyTeamId = match.team1Id;
+        }
+
+        Team enemyTeam = teamRepository.findByTeamId(enemyTeamId);
+        return new TeamResponseDto(enemyTeam);
     }
 }


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
X
## 🛠️ 뭘 했는지
1. 매칭 성사 후 서비스 구현을 위한 구조 정의

2. 매치 성사 후 상대팀 정보 조회를 위한 request DTO 정의

3. 매치 성사 후 상대팀 정보 조회 기능 구현

현재 team, match entity 및 repository가 구현이 돼있지 않고 다른 팀원에게 역할 분담이 돼있기 때문에 섣불리 건드릴 수가 없는 상황입니다. 역할 분담을 다시 고민해보긴 해야할 것 같습니다.

## 📷 스크린샷
X
## ✅ 확인 사항
- [ ] 로컬에서 잘 돌아감 → entity가 없기 때문에 실행 불가능
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
1. 문서 주석 작성해보았는데 적절한지 여쭤보고 싶습니다.

2. 다른 팀원에게 분담된 부분이 제 코드 작성에도 필요한 부분인데, 이런 경우에는 어떻게 해결해야할까요? 일단 구현이 돼있다 가정하고 작성했으나 실행이 불가능하고 추후에 다른 팀원이 구현을 끝냈을 때 인터페이스가 맞지 않는다면 다시 수정해야하기 때문에 일을 2번하게 될 것 같습니다. 

---

*PR 확인 부탁드려요! 🙏*