### PR TITLE
feat: 팀 멤버, 팀 리뷰, 용병 리뷰 Entity 구현 및 Enum 파일 상수화

### DIFF
--- a/src/main/java/com/shootdoori/match/dto/TeamMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/TeamMapper.java
@@ -46,10 +46,10 @@ public class TeamMapper {
      */
     private static TeamType parseToTeamType(String value) {
         if (value == null) {
-            return TeamType.기타;
+            return TeamType.OTHER;
         }
 
-        return TeamType.from(value);
+        return TeamType.fromDisplayName(value);
     }
 
     /**

--- a/src/main/java/com/shootdoori/match/dto/TeamMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/TeamMapper.java
@@ -60,9 +60,9 @@ public class TeamMapper {
      */
     private static SkillLevel parseToSkillLevel(String value) {
         if (value == null) {
-            return SkillLevel.아마추어;
+            return SkillLevel.AMATEUR;
         }
 
-        return SkillLevel.from(value);
+        return SkillLevel.fromDisplayName(value);
     }
 }

--- a/src/main/java/com/shootdoori/match/entity/MercenaryReview.java
+++ b/src/main/java/com/shootdoori/match/entity/MercenaryReview.java
@@ -1,0 +1,162 @@
+package com.shootdoori.match.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDateTime;
+import org.hibernate.annotations.Check;
+
+@Entity
+@Table(
+    name = "mercenary_review",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"match_id", "reviewer_team_id", "mercenary_user_id"})
+    }
+)
+@Check(
+    name = "ck_mercenary_review_ratings",
+    constraints =
+        "overall_rating BETWEEN 1 AND 5 " +
+            "AND skill_rating BETWEEN 1 AND 5 " +
+            "AND manner_rating BETWEEN 1 AND 5 " +
+            "AND communication_rating BETWEEN 1 AND 5"
+)
+public class MercenaryReview {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mercenary_review_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "match_id", nullable = false)
+    private Match match;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reviewer_team_id", nullable = false)
+    private Team reviewerTeam;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "mercenary_user_id", nullable = false)
+    private User mercenaryUser;
+
+    @Column(name = "mercenary_name", nullable = false, length = 100)
+    private String mercenaryName;
+
+    @Min(1) @Max(5)
+    @Column(name = "overall_rating", nullable = false)
+    private int overallRating;
+
+    @Min(1) @Max(5)
+    @Column(name = "skill_rating", nullable = false)
+    private int skillRating;
+
+    @Min(1) @Max(5)
+    @Column(name = "manner_rating", nullable = false)
+    private int mannerRating;
+
+    @Min(1) @Max(5)
+    @Column(name = "communication_rating", nullable = false)
+    private int communicationRating;
+
+    @Column(name = "comment", length = 300)
+    private String comment;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    protected MercenaryReview() {
+    }
+
+    public MercenaryReview(Match match,
+        Team reviewerTeam,
+        User mercenaryUser,
+        String mercenaryName,
+        int overallRating,
+        int skillRating,
+        int mannerRating,
+        int communicationRating,
+        String comment) {
+        this.match = match;
+        this.reviewerTeam = reviewerTeam;
+        this.mercenaryUser = mercenaryUser;
+        this.mercenaryName = mercenaryName;
+        this.overallRating = overallRating;
+        this.skillRating = skillRating;
+        this.mannerRating = mannerRating;
+        this.communicationRating = communicationRating;
+        this.comment = comment;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Match getMatch() {
+        return match;
+    }
+
+    public Team getReviewerTeam() {
+        return reviewerTeam;
+    }
+
+    public User getMercenaryUser() {
+        return mercenaryUser;
+    }
+
+    public String getMercenaryName() {
+        return mercenaryName;
+    }
+
+    public int getOverallRating() {
+        return overallRating;
+    }
+
+    public int getSkillRating() {
+        return skillRating;
+    }
+
+    public int getMannerRating() {
+        return mannerRating;
+    }
+
+    public int getCommunicationRating() {
+        return communicationRating;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/shootdoori/match/entity/SkillLevel.java
+++ b/src/main/java/com/shootdoori/match/entity/SkillLevel.java
@@ -1,15 +1,26 @@
 package com.shootdoori.match.entity;
 
 public enum SkillLevel {
-    프로,
-    세미프로,
-    아마추어;
+    PRO("프로"),
+    SEMI_PRO("세미프로"),
+    AMATEUR("아마추어");
 
-    public static SkillLevel from(String value) {
-        return switch (value) {
-            case "프로" -> SkillLevel.프로;
-            case "세미프로" -> SkillLevel.세미프로;
-            default -> SkillLevel.아마추어; // null 또는 매칭 실패 시 기본값
-        };
+    private final String displayName;
+
+    SkillLevel(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public static SkillLevel fromDisplayName(String displayName) {
+        for (SkillLevel level : values()) {
+            if (level.displayName.equals(displayName)) {
+                return level;
+            }
+        }
+        throw new IllegalArgumentException("Unknown skill level: " + displayName);
     }
 }

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -43,7 +43,7 @@ public class Team {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "SKILL_LEVEL", nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '아마추어'")
-    private SkillLevel skillLevel = SkillLevel.아마추어;
+    private SkillLevel skillLevel = SkillLevel.AMATEUR;
 
     @Column(name = "DESCRIPTION", length = 1000)
     private String description;
@@ -64,7 +64,7 @@ public class Team {
         this.university = university;
         this.teamType = teamType != null ? teamType : TeamType.OTHER;
         this.memberCount = (memberCount == null || memberCount < 0) ? 0 : memberCount;
-        this.skillLevel = skillLevel != null ? skillLevel : SkillLevel.아마추어;
+        this.skillLevel = skillLevel != null ? skillLevel : SkillLevel.AMATEUR;
         this.description = description;
     }
 

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -36,7 +36,7 @@ public class Team {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "TEAM_TYPE", nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '동아리'")
-    private TeamType teamType = TeamType.기타;
+    private TeamType teamType = TeamType.OTHER;
 
     @Column(name = "MEMBER_COUNT", nullable = false, columnDefinition = "INT DEFAULT 0")
     private Integer memberCount = 0;
@@ -62,7 +62,7 @@ public class Team {
         this.teamName = teamName;
         this.captain = captain;
         this.university = university;
-        this.teamType = teamType != null ? teamType : TeamType.기타;
+        this.teamType = teamType != null ? teamType : TeamType.OTHER;
         this.memberCount = (memberCount == null || memberCount < 0) ? 0 : memberCount;
         this.skillLevel = skillLevel != null ? skillLevel : SkillLevel.아마추어;
         this.description = description;

--- a/src/main/java/com/shootdoori/match/entity/TeamMember.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamMember.java
@@ -1,0 +1,92 @@
+package com.shootdoori.match.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "team_member",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"team_id", "user_id"})
+    }
+)
+public class TeamMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_member_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    private TeamMemberRole role = TeamMemberRole.MEMBER;
+
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    protected TeamMember() { }
+
+    public TeamMember(Team team, User user, TeamMemberRole role) {
+        this.team = team;
+        this.user = user;
+        this.role = role != null ? role : TeamMemberRole.MEMBER;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.joinedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public TeamMemberRole getRole() {
+        return role;
+    }
+
+    public LocalDateTime getJoinedAt() {
+        return joinedAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/shootdoori/match/entity/TeamMemberRole.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamMemberRole.java
@@ -1,0 +1,26 @@
+package com.shootdoori.match.entity;
+
+public enum TeamMemberRole {
+    LEADER("회장"),
+    VICE_LEADER("부회장"),
+    MEMBER("일반멤버");
+
+    private final String displayName;
+
+    TeamMemberRole(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public static TeamMemberRole fromDisplayName(String displayName) {
+        for (TeamMemberRole role : values()) {
+            if (role.displayName.equals(displayName)) {
+                return role;
+            }
+        }
+        throw new IllegalArgumentException("Unknown role: " + displayName);
+    }
+}

--- a/src/main/java/com/shootdoori/match/entity/TeamReview.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamReview.java
@@ -1,0 +1,145 @@
+package com.shootdoori.match.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDateTime;
+import org.hibernate.annotations.Check;
+
+@Entity
+@Table(
+    name = "team_review",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"match_id", "reviewer_team_id"})
+    }
+)
+@Check(
+    name = "ck_team_review_ratings",
+    constraints =
+        "rating BETWEEN 1 AND 5 " +
+            "AND (punctuality_rating IS NULL OR (punctuality_rating BETWEEN 1 AND 5)) " +
+            "AND (sportsmanship_rating IS NULL OR (sportsmanship_rating BETWEEN 1 AND 5))"
+)
+public class TeamReview {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "match_id", nullable = false)
+    private Match match;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reviewer_team_id", nullable = false)
+    private Team reviewerTeam;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reviewed_team_id", nullable = false)
+    private Team reviewedTeam;
+
+    @Min(1)
+    @Max(5)
+    @Column(name = "rating", nullable = false)
+    private int rating;
+
+    @Column(name = "comment", length = 500)
+    private String comment;
+
+    @Min(1)
+    @Max(5)
+    @Column(name = "punctuality_rating")
+    private Integer punctualityRating;
+
+    @Min(1)
+    @Max(5)
+    @Column(name = "sportsmanship_rating")
+    private Integer sportsmanshipRating;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    protected TeamReview() {
+    }
+
+    public TeamReview(Match match,
+        Team reviewerTeam,
+        Team reviewedTeam,
+        int rating,
+        String comment,
+        Integer punctualityRating,
+        Integer sportsmanshipRating) {
+        this.match = match;
+        this.reviewerTeam = reviewerTeam;
+        this.reviewedTeam = reviewedTeam;
+        this.rating = rating;
+        this.comment = comment;
+        this.punctualityRating = punctualityRating;
+        this.sportsmanshipRating = sportsmanshipRating;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Match getMatch() {
+        return match;
+    }
+
+    public Team getReviewerTeam() {
+        return reviewerTeam;
+    }
+
+    public Team getReviewedTeam() {
+        return reviewedTeam;
+    }
+
+    public int getRating() {
+        return rating;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public Integer getPunctualityRating() {
+        return punctualityRating;
+    }
+
+    public Integer getSportsmanshipRating() {
+        return sportsmanshipRating;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지
- TeamMember 엔티티 구현 
  - (team_id, user_id) 유니크 제약  
  - joinedAt/updatedAt 자동 관리  

- TeamReview 엔티티 구현  
  - (match_id, reviewer_team_id) 유니크 제약  
  - 평점(1~5) 범위 검증 (@Min/@Max + @Check)    

- MercenaryReview 엔티티 구현  
  - (match_id, reviewer_team_id, mercenary_user_id) 유니크 제약  
  - 종합/실력/매너/소통 평점 1~5 범위 검증  

- Enum 상수화  
  - TeamMemberRole → LEADER("회장"), VICE_LEADER("부회장"), MEMBER("일반멤버")  
  - SkillLevel → PRO("프로"), SEMI_PRO("세미프로"), AMATEUR("아마추어")  
---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
- 엔티티 어색한 점 있는지 봐주세요 !
---

*PR 확인 부탁드려요! 🙏*