### PR TITLE
feat(team): 대학교명 기준 팀 페이징 조회 구현

### DIFF
--- a/src/main/java/com/shootdoori/match/controller/TeamController.java
+++ b/src/main/java/com/shootdoori/match/controller/TeamController.java
@@ -36,6 +36,7 @@ public class TeamController {
         // TODO: JWT 토큰에서 유저 데이터를 가져와 captain 변수에 넣어야 한다.
         ProfileCreateRequest createRequest = new ProfileCreateRequest(
             "김학생",
+            "아마추어",
             "student@example.com",
             "student@kangwon.ac.kr",
             "010-1234-5678",

--- a/src/main/java/com/shootdoori/match/controller/TeamController.java
+++ b/src/main/java/com/shootdoori/match/controller/TeamController.java
@@ -6,6 +6,7 @@ import com.shootdoori.match.dto.TeamDetailResponseDto;
 import com.shootdoori.match.dto.TeamRequestDto;
 import com.shootdoori.match.entity.User;
 import com.shootdoori.match.service.TeamService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -53,12 +55,24 @@ public class TeamController {
         return new ResponseEntity<>(teamService.findById(id), HttpStatus.OK);
     }
 
+    @GetMapping
+    public ResponseEntity<Page<TeamDetailResponseDto>> findAllByUniversity(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size,
+        @RequestParam String university
+    ) {
+
+        return new ResponseEntity<>(teamService.findAllByUniversity(page, size, university),
+            HttpStatus.OK);
+    }
+
     @PutMapping("/{id}")
     public ResponseEntity<TeamDetailResponseDto> update(
         @PathVariable Long id,
         @RequestBody TeamRequestDto requestDto
     ) {
-        return new ResponseEntity<TeamDetailResponseDto>(teamService.update(id, requestDto), HttpStatus.OK);
+        return new ResponseEntity<TeamDetailResponseDto>(teamService.update(id, requestDto),
+            HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/shootdoori/match/dto/CreateTeamResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/CreateTeamResponseDto.java
@@ -3,7 +3,7 @@ package com.shootdoori.match.dto;
 public record CreateTeamResponseDto(
     Long teamId,
     String message,
-    String teamUrl
+    String teamUrl  // 생성된 팀의 접근 URL (예: "/api/teams/{id}")
 ) {
 
 }

--- a/src/main/java/com/shootdoori/match/dto/CreateTeamResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/CreateTeamResponseDto.java
@@ -1,9 +1,9 @@
 package com.shootdoori.match.dto;
 
 public record CreateTeamResponseDto(
-    Long teamId,     // 생성된 팀 ID
-    String message,  // 응답 메시지 (예: "팀이 성공적으로 생성되었습니다.")
-    String teamUrl   // 생성된 팀의 접근 URL (예: "/api/teams/{id}")
+    Long teamId,
+    String message,
+    String teamUrl
 ) {
 
 }

--- a/src/main/java/com/shootdoori/match/dto/TeamDetailResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/TeamDetailResponseDto.java
@@ -4,14 +4,14 @@ import com.shootdoori.match.entity.SkillLevel;
 import com.shootdoori.match.entity.TeamType;
 
 public record TeamDetailResponseDto(
-    Long id,            // 팀 ID
-    String name,        // 팀 이름
-    String description, // 팀 소개
-    String university,  // 대학교
-    SkillLevel skillLevel,  // 실력 수준
-    TeamType teamType,    // 팀 유형
-    Integer memberCount,// 팀원 수
-    String createdAt    // 생성 일자
+    Long id,
+    String name,
+    String description,
+    String university,
+    SkillLevel skillLevel,
+    TeamType teamType,
+    Integer memberCount,
+    String createdAt
 ) {
 
 }

--- a/src/main/java/com/shootdoori/match/dto/TeamMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/TeamMapper.java
@@ -39,12 +39,6 @@ public class TeamMapper {
             team.getCreatedAt().toString());
     }
 
-    /**
-     * 문자열 입력("중앙동아리", "과동아리", 그 외)을 Enum TeamType 으로 변환하는 메서드
-     *
-     * @param value 요청 DTO에서 넘어온 문자열
-     * @return TeamType Enum 값
-     */
     private static TeamType parseToTeamType(String value) {
         if (value == null) {
             return TeamType.OTHER;
@@ -53,12 +47,6 @@ public class TeamMapper {
         return TeamType.fromDisplayName(value);
     }
 
-    /**
-     * 문자열 입력("프로", "세미프로", 그 외)을 Enum SkillLevel 으로 변환하는 메서드
-     *
-     * @param value 요청 DTO에서 넘어온 문자열
-     * @return SkillLevel Enum 값
-     */
     private static SkillLevel parseToSkillLevel(String value) {
         if (value == null) {
             return SkillLevel.AMATEUR;

--- a/src/main/java/com/shootdoori/match/dto/TeamMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/TeamMapper.java
@@ -23,12 +23,12 @@ public class TeamMapper {
         );
     }
 
-    public static CreateTeamResponseDto toCreateTeamResponse(Team team) {
+    public CreateTeamResponseDto toCreateTeamResponse(Team team) {
         Long id = team.getTeamId();
         return new CreateTeamResponseDto(id, "팀이 성공적으로 생성되었습니다.", "/api/teams/" + id);
     }
 
-    public static TeamDetailResponseDto toTeamDetailResponse(Team team) {
+    public TeamDetailResponseDto toTeamDetailResponse(Team team) {
         return new TeamDetailResponseDto(team.getTeamId(),
             team.getTeamName(),
             team.getDescription(),

--- a/src/main/java/com/shootdoori/match/dto/TeamRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/TeamRequestDto.java
@@ -1,11 +1,11 @@
 package com.shootdoori.match.dto;
 
 public record TeamRequestDto(
-    String name,        // 팀 이름
-    String description, // 팀 소개 (최대 1000자)
-    String university,  // 소속 대학교
-    String skillLevel,  // 실력 수준: "아마추어" | "세미프로" | "프로"
-    String teamType    // 팀 유형: "중앙동아리" | "과동아리" | "기타"
+    String name,
+    String description,
+    String university,
+    String skillLevel,
+    String teamType
 ) {
 
 }

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -16,7 +16,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "teams")
+@Table(name = "team")
 public class Team {
 
     @Id

--- a/src/main/java/com/shootdoori/match/entity/User.java
+++ b/src/main/java/com/shootdoori/match/entity/User.java
@@ -4,6 +4,8 @@ import com.shootdoori.match.dto.ProfileCreateRequest;
 import com.shootdoori.match.dto.ProfileUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;

--- a/src/main/java/com/shootdoori/match/repository/TeamRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/TeamRepository.java
@@ -1,8 +1,10 @@
 package com.shootdoori.match.repository;
 
 import com.shootdoori.match.entity.Team;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
-
+    public Page<Team> findAllByUniversity(String university, Pageable pageable);
 }

--- a/src/main/java/com/shootdoori/match/service/TeamService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamService.java
@@ -1,9 +1,9 @@
 package com.shootdoori.match.service;
 
-import com.shootdoori.match.dto.CreateTeamRequestDto;
 import com.shootdoori.match.dto.CreateTeamResponseDto;
 import com.shootdoori.match.dto.TeamDetailResponseDto;
 import com.shootdoori.match.dto.TeamMapper;
+import com.shootdoori.match.dto.TeamRequestDto;
 import com.shootdoori.match.entity.Team;
 import com.shootdoori.match.entity.User;
 import com.shootdoori.match.exception.CaptainNotFoundException;
@@ -29,7 +29,7 @@ public class TeamService {
         this.teamMapper = teamMapper;
     }
 
-    public CreateTeamResponseDto create(CreateTeamRequestDto requestDto, User captain) {
+    public CreateTeamResponseDto create(TeamRequestDto requestDto, User captain) {
         if (captain == null) {
             throw new CaptainNotFoundException("팀장 정보가 없습니다.");
         }

--- a/src/main/java/com/shootdoori/match/service/TeamService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamService.java
@@ -9,6 +9,10 @@ import com.shootdoori.match.entity.User;
 import com.shootdoori.match.exception.CaptainNotFoundException;
 import com.shootdoori.match.exception.TeamNotFoundException;
 import com.shootdoori.match.repository.TeamRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,10 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class TeamService {
 
     private final TeamRepository teamRepository;
+    private final TeamMapper teamMapper;
 
 
-    public TeamService(TeamRepository teamRepository) {
+    public TeamService(TeamRepository teamRepository, TeamMapper teamMapper) {
         this.teamRepository = teamRepository;
+        this.teamMapper = teamMapper;
     }
 
     public CreateTeamResponseDto create(TeamRequestDto requestDto, User captain) {
@@ -31,7 +37,7 @@ public class TeamService {
         Team team = TeamMapper.toEntity(requestDto, captain);
         Team savedTeam = teamRepository.save(team);
 
-        return TeamMapper.toCreateTeamResponse(savedTeam);
+        return teamMapper.toCreateTeamResponse(savedTeam);
     }
 
     @Transactional(readOnly = true)
@@ -39,7 +45,16 @@ public class TeamService {
         Team team = teamRepository.findById(id).orElseThrow(() ->
             new TeamNotFoundException("해당 팀을 찾을 수 없습니다. id = " + id));
 
-        return TeamMapper.toTeamDetailResponse(team);
+        return teamMapper.toTeamDetailResponse(team);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<TeamDetailResponseDto> findAllByUniversity(int page, int size, String university) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("teamName").ascending());
+
+        Page<Team> teamPage = teamRepository.findAllByUniversity(university, pageable);
+
+        return teamPage.map(teamMapper::toTeamDetailResponse);
     }
 
     public TeamDetailResponseDto update(Long id, TeamRequestDto requestDto) {
@@ -49,7 +64,7 @@ public class TeamService {
         team.changeTeamInfo(requestDto.name(), requestDto.university(),
             requestDto.skillLevel(), requestDto.description());
 
-        return TeamMapper.toTeamDetailResponse(team);
+        return teamMapper.toTeamDetailResponse(team);
     }
 
     public void delete(Long id) {


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지
1. 주 변경 사항
- Repository: findAllByUniversity(String, Pageable)
- Service: Page<Team> → Page<TeamDetailResponseDto> 매핑
- Controller: GET /api/teams?university=...&page=..&size=..
- 기본 정렬: teamName ASC

2. 추가 변경 사항
- teams -> team 테이블명 변경
- TeamMapper 빈 주입에 따른 static 키워드 제거
- 주석 제거

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [] 로컬에서 잘 돌아감 (아직 로컬 실행 불가)
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
- 팀 전체 조회 기능이 필요한지 의견 하나씩 더 남겨주면 좋을 것 같습니다.
- 대학교명 기준 팀 페이징 조회 flow 좀 봐주세요 !

---

*PR 확인 부탁드려요! 🙏*