### PR TITLE
feat(teammember): 팀 멤버 생성 기능 구현

### DIFF
--- a/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
+++ b/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
@@ -3,6 +3,7 @@ package com.shootdoori.match.controller;
 import com.shootdoori.match.dto.TeamMemberRequestDto;
 import com.shootdoori.match.dto.TeamMemberResponseDto;
 import com.shootdoori.match.service.TeamMemberService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,6 +30,8 @@ public class TeamMemberController {
     public ResponseEntity<TeamMemberResponseDto> create(@PathVariable Long teamId,
         @RequestBody TeamMemberRequestDto requestDto) {
 
+        return new ResponseEntity<>(teamMemberService.create(teamId, requestDto),
+            HttpStatus.CREATED);
     }
 
 //    @GetMapping("/{memberId}")

--- a/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
+++ b/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
@@ -1,0 +1,52 @@
+package com.shootdoori.match.controller;
+
+import com.shootdoori.match.dto.TeamMemberRequestDto;
+import com.shootdoori.match.dto.TeamMemberResponseDto;
+import com.shootdoori.match.service.TeamMemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/teams/{teamId}/members")
+public class TeamMemberController {
+
+    private final TeamMemberService teamMemberService;
+
+    public TeamMemberController(TeamMemberService teamMemberService) {
+        this.teamMemberService = teamMemberService;
+    }
+
+//    @GetMapping
+//    public ResponseEntity<List<TeamMemberResponseDto>> findAllByTeamId(@PathVariable Long teamId) {
+//        ...
+//    }
+
+    @PostMapping
+    public ResponseEntity<TeamMemberResponseDto> create(@PathVariable Long teamId,
+        @RequestBody TeamMemberRequestDto requestDto) {
+
+    }
+
+//    @GetMapping("/{memberId}")
+//    public ResponseEntity<TeamMemberResponseDto> findById(@PathVariable Long teamId,
+//        @PathVariable Long memberId) {
+//
+//    }
+//
+//    @PutMapping("/{memberId}")
+//    public ResponseEntity<Void> update(@PathVariable Long teamId,
+//        @PathVariable Long memberId,
+//        @RequestBody UpdateTeamMemberRequestDto request) {
+//
+//    }
+//
+//    @DeleteMapping("/{memberId}")
+//    public ResponseEntity<Void> delete(@PathVariable Long teamId,
+//        @PathVariable Long memberId) {
+//
+//    }
+}

--- a/src/main/java/com/shootdoori/match/dto/TeamMemberRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/TeamMemberRequestDto.java
@@ -1,0 +1,9 @@
+package com.shootdoori.match.dto;
+
+public record TeamMemberRequestDto(
+    Long userId,
+    String role
+) {
+
+}
+

--- a/src/main/java/com/shootdoori/match/dto/TeamMemberResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/TeamMemberResponseDto.java
@@ -1,0 +1,15 @@
+package com.shootdoori.match.dto;
+
+import java.time.LocalDateTime;
+
+public record TeamMemberResponseDto(
+    Long id,
+    Long userId,
+    String name,
+    String email,
+    String position,
+    String role,
+    LocalDateTime joinedAt
+) {
+
+}

--- a/src/main/java/com/shootdoori/match/dto/UpdateTeamMemberRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/UpdateTeamMemberRequestDto.java
@@ -1,0 +1,7 @@
+package com.shootdoori.match.dto;
+
+public record UpdateTeamMemberRequestDto(
+    String role
+) {
+
+}

--- a/src/main/java/com/shootdoori/match/entity/Position.java
+++ b/src/main/java/com/shootdoori/match/entity/Position.java
@@ -1,0 +1,52 @@
+package com.shootdoori.match.entity;
+
+public enum Position {
+
+    GK("골키퍼"),
+    DF("수비수"),
+    MF("미드필더"),
+    FW("공격수"),
+
+    // 수비
+    CB("센터백"),
+    FB("풀백"),
+    WB("윙백"),
+
+    CM("중앙 미드필더"),
+    DM("수비형 미드필더"),
+    AM("공격형 미드필더"),
+    LM("측면 미드필더(좌)"),
+    RM("측면 미드필더(우)"),
+
+    CF("중앙 공격수"),
+    SS("세컨드 스트라이커"),
+    LW("윙어(좌)"),
+    RW("윙어(우)");
+
+    private final String displayName;
+
+    Position(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public static Position fromDisplayName(String displayName) {
+        for (Position p : values()) {
+            if (p.displayName.equals(displayName)) {
+                return p;
+            }
+        }
+        throw new IllegalArgumentException("Unknown position: " + displayName);
+    }
+
+    public static Position fromCode(String code) {
+        try {
+            return Position.valueOf(code.toUpperCase());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unknown position code: " + code);
+        }
+    }
+}

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -1,5 +1,6 @@
 package com.shootdoori.match.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,10 +11,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "teams")
@@ -53,6 +57,9 @@ public class Team {
 
     @Column(name = "UPDATED_AT")
     private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "teams", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<TeamMember> memberList = new ArrayList<>();
 
     protected Team() {
     }
@@ -119,6 +126,10 @@ public class Team {
         return updatedAt;
     }
 
+    public List<TeamMember> getMemberList() {
+        return memberList;
+    }
+
     private void validateTeamName(String name) {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("팀 이름은 필수입니다.");
@@ -148,6 +159,17 @@ public class Team {
             throw new IllegalArgumentException("멤버 수는 0~100명입니다.");
         }
     }
+
+    public void addMember(TeamMember member) {
+        memberList.add(member);
+        member.setTeam(this);
+    }
+
+    public void removeMember(TeamMember member) {
+        memberList.remove(member);
+        member.setTeam(null);
+    }
+
 
     public void changeTeamInfo(String teamName,
         String university,

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -170,6 +170,15 @@ public class Team {
         member.setTeam(null);
     }
 
+    public void increaseMemberCount() {
+        validateMemberCount(this.memberCount + 1);
+        this.memberCount++;
+    }
+
+    public void decreaseMemberCount() {
+        validateMemberCount(this.memberCount - 1);
+        this.memberCount--;
+    }
 
     public void changeTeamInfo(String teamName,
         String university,

--- a/src/main/java/com/shootdoori/match/entity/TeamMember.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamMember.java
@@ -48,7 +48,8 @@ public class TeamMember {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    protected TeamMember() { }
+    protected TeamMember() {
+    }
 
     public TeamMember(Team team, User user, TeamMemberRole role) {
         this.team = team;
@@ -88,5 +89,9 @@ public class TeamMember {
 
     public LocalDateTime getUpdatedAt() {
         return updatedAt;
+    }
+
+    public void setTeam(Team team) {
+        this.team = team;
     }
 }

--- a/src/main/java/com/shootdoori/match/entity/User.java
+++ b/src/main/java/com/shootdoori/match/entity/User.java
@@ -49,6 +49,10 @@ public class User {
     @Column(length = 500)
     private String bio;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "POSITION", nullable = false, length = 2)
+    private Position position;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -210,6 +214,10 @@ public class User {
 
     public String getBio() {
         return this.bio;
+    }
+
+    public Position getPosition() {
+        return this.position;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
@@ -4,5 +4,5 @@ import com.shootdoori.match.entity.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
-
+    public boolean existsByTeamIdAndUserId(Long teamId, Long userId);
 }

--- a/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
@@ -1,0 +1,8 @@
+package com.shootdoori.match.repository;
+
+import com.shootdoori.match.entity.TeamMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+}

--- a/src/main/java/com/shootdoori/match/service/TeamMemberService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamMemberService.java
@@ -1,13 +1,66 @@
 package com.shootdoori.match.service;
 
+import com.shootdoori.match.dto.TeamMemberRequestDto;
+import com.shootdoori.match.dto.TeamMemberResponseDto;
+import com.shootdoori.match.entity.Team;
+import com.shootdoori.match.entity.TeamMember;
+import com.shootdoori.match.entity.TeamMemberRole;
+import com.shootdoori.match.entity.User;
+import com.shootdoori.match.exception.TeamNotFoundException;
+import com.shootdoori.match.repository.ProfileRepository;
 import com.shootdoori.match.repository.TeamMemberRepository;
+import com.shootdoori.match.repository.TeamRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class TeamMemberService {
-    private final TeamMemberRepository teamMemberRepository;
 
-    public TeamMemberService(TeamMemberRepository teamMemberRepository) {
+    private final TeamMemberRepository teamMemberRepository;
+    private final TeamRepository teamRepository;
+    private final ProfileRepository profileRepository;
+
+    public TeamMemberService(TeamMemberRepository teamMemberRepository,
+        TeamRepository teamRepository, ProfileRepository profileRepository) {
         this.teamMemberRepository = teamMemberRepository;
+        this.teamRepository = teamRepository;
+        this.profileRepository = profileRepository;
+    }
+
+    public TeamMemberResponseDto create(Long teamId, TeamMemberRequestDto requestDto) {
+
+        Long userId = requestDto.userId();
+
+        Team team = teamRepository.findById(teamId).orElseThrow(() ->
+            new TeamNotFoundException("해당 팀을 찾을 수 없습니다. id = " + teamId));
+
+        User user = profileRepository.findById(userId).orElseThrow(
+            () -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다. id = " + userId));
+
+        if (!team.getUniversity().equals(user.getUniversity())) {
+            throw new IllegalStateException("팀 소속 대학과 동일한 대학의 사용자만 가입할 수 있습니다.");
+        }
+
+        if (teamMemberRepository.existsByTeamIdAndUserId(teamId, userId)) {
+            throw new IllegalStateException("이미 해당 팀의 멤버입니다.");
+        }
+
+        if (team.getMemberCount() >= 100) {
+            throw new IllegalStateException("팀 정원이 가득 찼습니다. (최대 100명)");
+        }
+
+        TeamMemberRole teamMemberRole = TeamMemberRole.fromDisplayName(requestDto.role());
+
+        TeamMember teamMember = new TeamMember(team, user, teamMemberRole);
+        TeamMember savedTeamMember = teamMemberRepository.save(teamMember);
+
+        return new TeamMemberResponseDto(savedTeamMember.getId(),
+            savedTeamMember.getUser().getId(),
+            savedTeamMember.getUser().getName(),
+            savedTeamMember.getUser().getEmail(),
+            savedTeamMember.getUser().getPosition().toString(),
+            savedTeamMember.getRole().toString(),
+            savedTeamMember.getJoinedAt());
     }
 }

--- a/src/main/java/com/shootdoori/match/service/TeamMemberService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamMemberService.java
@@ -1,0 +1,13 @@
+package com.shootdoori.match.service;
+
+import com.shootdoori.match.repository.TeamMemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TeamMemberService {
+    private final TeamMemberRepository teamMemberRepository;
+
+    public TeamMemberService(TeamMemberRepository teamMemberRepository) {
+        this.teamMemberRepository = teamMemberRepository;
+    }
+}


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지
* TeamMemberController: 멤버 생성용 POST 엔드포인트 추가
* TeamMemberService: 멤버 검증 및 생성 로직 구현
* TeamMemberRepository: 중복 팀 멤버 확인 메서드 추가
* Team entity에 멤버 수 편의 메서드 추가
* User entity에 멤버 역할용 포지션 필드 추가

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [ ] 로컬에서 잘 돌아감 (아직 스프링 실행 X)
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
- 아직 편의 메서드 구현 부분이 어색한 것 같습니다. 피드백 환영합니다 :D

---

*PR 확인 부탁드려요! 🙏*