### PR TITLE
refactor: TeamMember 매핑 수정 및 Team 엔티티 컬럼을 Value Object로 리팩토링

### DIFF
--- a/src/main/java/com/shootdoori/match/dto/ProfileMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileMapper.java
@@ -12,7 +12,7 @@ public class ProfileMapper {
 
         return new ProfileResponse(
             user.getName(),
-            user.getUniversity(),
+            user.getUniversity().name(),
             user.getCreatedAt()
         );
     }

--- a/src/main/java/com/shootdoori/match/dto/TeamMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/TeamMapper.java
@@ -30,12 +30,12 @@ public class TeamMapper {
 
     public TeamDetailResponseDto toTeamDetailResponse(Team team) {
         return new TeamDetailResponseDto(team.getTeamId(),
-            team.getTeamName(),
-            team.getDescription(),
-            team.getUniversity(),
+            team.getTeamName().name(),
+            team.getDescription().description(),
+            team.getUniversity().name(),
             team.getSkillLevel(),
             team.getTeamType(),
-            team.getMemberCount(),
+            team.getMemberCount().count(),
             team.getCreatedAt().toString());
     }
 

--- a/src/main/java/com/shootdoori/match/dto/TeamResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/TeamResponseDto.java
@@ -20,13 +20,13 @@ public record TeamResponseDto(Long teamId,
 
     public TeamResponseDto(Team team){
         this(team.getTeamId(),
-                team.getTeamName(),
+                team.getTeamName().name(),
                 team.getCaptain(),
-                team.getUniversity(),
+                team.getUniversity().name(),
                 team.getTeamType(),
-                team.getMemberCount(),
+                team.getMemberCount().count(),
                 team.getSkillLevel(),
-                team.getDescription(),
+                team.getDescription().description(),
                 team.getCreatedAt(),
                 team.getUpdatedAt()
         );

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "teams")
+@Table(name = "team")
 public class Team {
 
     @Id
@@ -68,7 +68,7 @@ public class Team {
     @Column(name = "UPDATED_AT")
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "teams", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<TeamMember> memberList = new ArrayList<>();
 
     protected Team() {

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -1,7 +1,13 @@
 package com.shootdoori.match.entity;
 
+import com.shootdoori.match.value.Description;
+import com.shootdoori.match.value.MemberCount;
+import com.shootdoori.match.value.TeamName;
+import com.shootdoori.match.value.UniversityName;
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -28,29 +34,33 @@ public class Team {
     @Column(name = "TEAM_ID")
     private Long teamId;
 
-    @Column(name = "TEAM_NAME", nullable = false, length = 100)
-    private String teamName;
+    @Embedded
+    @AttributeOverride(name = "name", column = @Column(name = "TEAM_NAME", nullable = false, length = 100))
+    private TeamName teamName;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "CAPTAIN_ID", nullable = false)
     private User captain;
 
-    @Column(name = "UNIVERSITY", nullable = false, length = 100)
-    private String university;
+    @Embedded
+    @AttributeOverride(name = "name", column = @Column(name = "UNIVERSITY", nullable = false, length = 100))
+    private UniversityName university;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "TEAM_TYPE", nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '동아리'")
+    @Column(name = "TEAM_TYPE", nullable = false, length = 20)
     private TeamType teamType = TeamType.OTHER;
 
-    @Column(name = "MEMBER_COUNT", nullable = false, columnDefinition = "INT DEFAULT 0")
-    private Integer memberCount = 0;
+    @Embedded
+    @AttributeOverride(name = "count", column = @Column(name = "MEMBER_COUNT", nullable = false))
+    private MemberCount memberCount = MemberCount.of(1);
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "SKILL_LEVEL", nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '아마추어'")
+    @Column(name = "SKILL_LEVEL", nullable = false, length = 20)
     private SkillLevel skillLevel = SkillLevel.AMATEUR;
 
-    @Column(name = "DESCRIPTION", length = 1000)
-    private String description;
+    @Embedded
+    @AttributeOverride(name = "description", column = @Column(name = "DESCRIPTION", length = 1000))
+    private Description description;
 
     @Column(name = "CREATED_AT", updatable = false)
     private LocalDateTime createdAt;
@@ -60,18 +70,18 @@ public class Team {
 
     @OneToMany(mappedBy = "teams", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<TeamMember> memberList = new ArrayList<>();
-    
+
     protected Team() {
     }
 
     public Team(String teamName, User captain, String university, TeamType teamType,
         SkillLevel skillLevel, String description) {
-        this.teamName = teamName;
+        this.teamName = TeamName.of(teamName);
         this.captain = captain;
-        this.university = university;
+        this.university = UniversityName.of(university);
         this.teamType = teamType != null ? teamType : TeamType.OTHER;
         this.skillLevel = skillLevel != null ? skillLevel : SkillLevel.AMATEUR;
-        this.description = description;
+        this.description = Description.of(description);
     }
 
     @PrePersist
@@ -90,7 +100,7 @@ public class Team {
         return teamId;
     }
 
-    public String getTeamName() {
+    public TeamName getTeamName() {
         return teamName;
     }
 
@@ -98,7 +108,7 @@ public class Team {
         return captain;
     }
 
-    public String getUniversity() {
+    public UniversityName getUniversity() {
         return university;
     }
 
@@ -106,7 +116,7 @@ public class Team {
         return teamType;
     }
 
-    public Integer getMemberCount() {
+    public MemberCount getMemberCount() {
         return memberCount;
     }
 
@@ -114,7 +124,7 @@ public class Team {
         return skillLevel;
     }
 
-    public String getDescription() {
+    public Description getDescription() {
         return description;
     }
 
@@ -130,54 +140,17 @@ public class Team {
         return memberList;
     }
 
-    private void validateTeamName(String name) {
-        if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("팀 이름은 필수입니다.");
-        }
-        if (name.length() > 100) {
-            throw new IllegalArgumentException("팀 이름은 최대 100자입니다.");
-        }
-    }
-
-    private void validateUniversity(String university) {
-        if (university == null || university.isBlank()) {
-            throw new IllegalArgumentException("대학교는 필수입니다.");
-        }
-        if (university.length() > 100) {
-            throw new IllegalArgumentException("대학교는 최대 100자입니다.");
-        }
-    }
-
-    private void validateDescription(String desc) {
-        if (desc != null && desc.length() > 1000) {
-            throw new IllegalArgumentException("설명은 최대 1000자입니다.");
-        }
-    }
-
-    private void validateMemberCount(int count) {
-        if (count < 0 || count > 100) {
-            throw new IllegalArgumentException("멤버 수는 0~100명입니다.");
-        }
-    }
 
     public void addMember(TeamMember member) {
         memberList.add(member);
         member.setTeam(this);
+        this.memberCount = this.memberCount.increase();
     }
 
     public void removeMember(TeamMember member) {
         memberList.remove(member);
         member.setTeam(null);
-    }
-
-    public void increaseMemberCount() {
-        validateMemberCount(this.memberCount + 1);
-        this.memberCount++;
-    }
-
-    public void decreaseMemberCount() {
-        validateMemberCount(this.memberCount - 1);
-        this.memberCount--;
+        this.memberCount = this.memberCount.decrease();
     }
 
     public void changeTeamInfo(String teamName,
@@ -185,13 +158,9 @@ public class Team {
         String skillLevel,
         String description) {
 
-        validateTeamName(teamName);
-        validateUniversity(university);
-        validateDescription(description);
-
-        this.teamName = teamName;
-        this.university = university;
+        this.teamName = TeamName.of(teamName);
+        this.university = UniversityName.of(university);
         this.skillLevel = SkillLevel.fromDisplayName(skillLevel);
-        this.description = description;
+        this.description = Description.of(description);
     }
 }

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -70,7 +70,7 @@ public class Team {
     @Column(name = "UPDATED_AT")
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "teams", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<TeamMember> members = new ArrayList<>();
 
 

--- a/src/main/java/com/shootdoori/match/entity/User.java
+++ b/src/main/java/com/shootdoori/match/entity/User.java
@@ -2,7 +2,10 @@ package com.shootdoori.match.entity;
 
 import com.shootdoori.match.dto.ProfileCreateRequest;
 import com.shootdoori.match.dto.ProfileUpdateRequest;
+import com.shootdoori.match.value.UniversityName;
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -13,10 +16,9 @@ import java.time.LocalDateTime;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import java.time.LocalDateTime;
-
 @Entity
 public class User {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -27,23 +29,24 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(name = "SKILL_LEVEL", nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '아마추어'")
     private SkillLevel skillLevel = SkillLevel.AMATEUR;
-  
+
     @Column(nullable = false, unique = true, length = 255)
     private String email;
 
-    @Column(name = "university_email",nullable = false, unique = true, length = 255)
+    @Column(name = "university_email", nullable = false, unique = true, length = 255)
     private String universityEmail;
 
-    @Column(name = "phone_number",nullable = false, unique = true, length = 13)
+    @Column(name = "phone_number", nullable = false, unique = true, length = 13)
     private String phoneNumber;
 
-    @Column(nullable = false, length = 100)
-    private String university;
+    @Embedded
+    @AttributeOverride(name = "name", column = @Column(name = "UNIVERSITY", nullable = false, length = 100))
+    private UniversityName university;
 
     @Column(nullable = false, length = 100)
     private String department;
 
-    @Column(name = "student_year",nullable = false, length = 2)
+    @Column(name = "student_year", nullable = false, length = 2)
     private String studentYear;
 
     @Column(length = 500)
@@ -65,21 +68,22 @@ public class User {
 
     }
 
-    private User(String name, String email, String universityEmail, String phoneNumber, String university, String department, String studentYear, String bio) {
-        validate(name, email, universityEmail, phoneNumber, university, department, studentYear, bio);
+    private User(String name, String email, String universityEmail, String phoneNumber,
+        String university, String department, String studentYear, String bio) {
         this.name = name;
         this.email = email;
         this.universityEmail = universityEmail;
         this.phoneNumber = phoneNumber;
-        this.university = university;
+        this.university = UniversityName.of(university);
         this.department = department;
         this.studentYear = studentYear;
         this.bio = bio;
     }
 
     public static User create(String name, String email, String universityEmail, String phoneNumber,
-                              String university, String department, String studentYear, String bio) {
-        return new User(name, email, universityEmail, phoneNumber, university, department, studentYear, bio);
+        String university, String department, String studentYear, String bio) {
+        return new User(name, email, universityEmail, phoneNumber, university, department,
+            studentYear, bio);
     }
 
     public User(ProfileCreateRequest createRequest) {
@@ -88,13 +92,14 @@ public class User {
         this.email = createRequest.email();
         this.universityEmail = createRequest.universityEmail();
         this.phoneNumber = createRequest.phoneNumber();
-        this.university = createRequest.university();
+        this.university = UniversityName.of(createRequest.university());
         this.department = createRequest.department();
         this.studentYear = createRequest.studentYear();
         this.bio = createRequest.bio();
     }
 
-    private void validate(String name, String email, String universityEmail, String phoneNumber, String university, String department, String studentYear, String bio) {
+    private void validate(String name, String email, String universityEmail, String phoneNumber,
+        String university, String department, String studentYear, String bio) {
         validateName(name);
         validateEmail(email);
         validateUniversityEmail(universityEmail);
@@ -200,7 +205,7 @@ public class User {
         return this.phoneNumber;
     }
 
-    public String getUniversity() {
+    public UniversityName getUniversity() {
         return this.university;
     }
 

--- a/src/main/java/com/shootdoori/match/service/TeamMemberService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamMemberService.java
@@ -48,7 +48,7 @@ public class TeamMemberService {
             throw new IllegalStateException("이미 해당 팀의 멤버입니다.");
         }
 
-        if (team.getMemberCount() >= MAX_MEMBER_COUNT) {
+        if (team.getMemberCount().count() >= MAX_MEMBER_COUNT) {
             throw new IllegalStateException("팀 정원이 가득 찼습니다. (최대 100명)");
         }
 

--- a/src/main/java/com/shootdoori/match/value/Description.java
+++ b/src/main/java/com/shootdoori/match/value/Description.java
@@ -1,0 +1,27 @@
+package com.shootdoori.match.value;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record Description(String description) {
+
+    private static final int MAX_DESCRIPTION_LENGTH = 1000;
+
+    public Description {
+        if (description != null && description.isBlank()) {
+            description = null;
+        }
+
+        if (description != null && description.length() > MAX_DESCRIPTION_LENGTH) {
+            throw new IllegalArgumentException("설명은 최대 1000자입니다.");
+        }
+    }
+
+    public static Description of(String description) {
+        return new Description(description);
+    }
+
+    public static Description empty() {
+        return new Description(null);
+    }
+}

--- a/src/main/java/com/shootdoori/match/value/MemberCount.java
+++ b/src/main/java/com/shootdoori/match/value/MemberCount.java
@@ -1,0 +1,28 @@
+package com.shootdoori.match.value;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record MemberCount(int count) {
+
+    private static final int MIN_MEMBERS = 1;
+    private static final int MAX_MEMBERS = 100;
+
+    public MemberCount {
+        if (count < MIN_MEMBERS || count > MAX_MEMBERS) {
+            throw new IllegalArgumentException("멤버 수는 1~100명입니다.");
+        }
+    }
+
+    public static MemberCount of(int count) {
+        return new MemberCount(count);
+    }
+
+    public MemberCount increase() {
+        return new MemberCount(count + 1);
+    }
+
+    public MemberCount decrease() {
+        return new MemberCount(count - 1);
+    }
+}

--- a/src/main/java/com/shootdoori/match/value/TeamName.java
+++ b/src/main/java/com/shootdoori/match/value/TeamName.java
@@ -19,4 +19,23 @@ public record TeamName(String name) {
     public static TeamName of(String name) {
         return new TeamName(name);
     }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        TeamName that = (TeamName) other;
+        return this.name.equals(that.name());
+    }
 }

--- a/src/main/java/com/shootdoori/match/value/TeamName.java
+++ b/src/main/java/com/shootdoori/match/value/TeamName.java
@@ -1,0 +1,22 @@
+package com.shootdoori.match.value;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record TeamName(String name) {
+
+    private static final int MAX_TEAM_NAME_LENGTH = 100;
+
+    public TeamName {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("팀 이름은 필수입니다.");
+        }
+        if (name.length() > MAX_TEAM_NAME_LENGTH) {
+            throw new IllegalArgumentException("팀 이름은 최대 100자입니다.");
+        }
+    }
+
+    public static TeamName of(String name) {
+        return new TeamName(name);
+    }
+}

--- a/src/main/java/com/shootdoori/match/value/UniversityName.java
+++ b/src/main/java/com/shootdoori/match/value/UniversityName.java
@@ -9,9 +9,6 @@ public record UniversityName(String name) {
     private static final int MAX_UNIVERSITY_NAME = 100;
 
     public UniversityName {
-        if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("대학교는 필수입니다.");
-        }
         if (name.length() > MAX_UNIVERSITY_NAME) {
             throw new IllegalArgumentException("대학교명은 최대 100자입니다.");
         }

--- a/src/main/java/com/shootdoori/match/value/UniversityName.java
+++ b/src/main/java/com/shootdoori/match/value/UniversityName.java
@@ -1,6 +1,7 @@
 package com.shootdoori.match.value;
 
 import jakarta.persistence.Embeddable;
+import java.util.Objects;
 
 @Embeddable
 public record UniversityName(String name) {
@@ -18,5 +19,24 @@ public record UniversityName(String name) {
 
     public static UniversityName of(String name) {
         return new UniversityName(name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        UniversityName that = (UniversityName) other;
+        return this.name.equals(that.name());
     }
 }

--- a/src/main/java/com/shootdoori/match/value/UniversityName.java
+++ b/src/main/java/com/shootdoori/match/value/UniversityName.java
@@ -1,0 +1,22 @@
+package com.shootdoori.match.value;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record UniversityName(String name) {
+
+    private static final int MAX_UNIVERSITY_NAME = 100;
+
+    public UniversityName {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("대학교는 필수입니다.");
+        }
+        if (name.length() > MAX_UNIVERSITY_NAME) {
+            throw new IllegalArgumentException("대학교명은 최대 100자입니다.");
+        }
+    }
+
+    public static UniversityName of(String name) {
+        return new UniversityName(name);
+    }
+}


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지

### 변경 내용
- Team 엔티티의 `@OneToMany(mappedBy)`를 'team'으로 변경 (TeamMember 엔티티 필드명과 일치)
- 테이블명을 스펙에 맞춰 teams → team으로 수정
- 엔티티와 DB 스키마 간 매핑 일관성 확보

- Team 엔티티의 mappedBy 속성을 'teams' → 'team'으로 수정
- `@Table`(name = "teams") → `@Table`(name = "team")으로 변경하여 DB 스펙 일치
- TeamMember 엔티티와의 양방향 매핑 정합성 확보

- TeamName, UniversityName VO에 equals, hashCode 오버라이딩
- user entity의 university 컬럼 타입을 UniversityName으로 통일

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
- VO(Value Object)를 위한 `value` 패키지를 생성하였습니다 :D

---

*PR 확인 부탁드려요! 🙏*