### PR TITLE
refactor(mercenary): 테스트 코드 리팩토링 및 Fixture 적용

### DIFF
--- a/src/test/java/com/shootdoori/mercenary/MercenaryRecruitmentTest.java
+++ b/src/test/java/com/shootdoori/mercenary/MercenaryRecruitmentTest.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -46,61 +47,39 @@ class MercenaryRecruitmentTest {
     @Mock
     private TeamRepository teamRepository;
 
-    private final Team testTeam = new Team(
-        "두리FC",
-        User.create(
-            "김학생",
-            "student@example.com",
-            "student@kangwon.ac.kr",
-            "010-1234-5678",
-            "강원대학교",
-            "컴퓨터공학과",
-            "20",
-            "안녕하세요! 축구를 좋아하는 대학생입니다."
-        ),
-        "강원대학교",
-        TeamType.CENTRAL_CLUB,
-        SkillLevel.AMATEUR,
-        "즐겜해요~"
-    );
-
+    // --- 테스트 픽스처(Test Fixture)로 분리된 객체들 ---
+    // 각 테스트에서 이 객체들을 재사용합니다.
+    private Team testTeam;
     private MercenaryRecruitment testRecruitment;
+    private RecruitmentCreateRequest createRequest;
 
+    // @BeforeEach: 각 테스트가 실행되기 전에 이 메서드가 호출되어
+    // 항상 깨끗하고 일관된 테스트 환경을 만들어줍니다.
     @BeforeEach
     void setUp() {
-        testRecruitment = MercenaryRecruitment.create(
-            testTeam,
-            LocalDate.now().plusDays(1),
-            LocalTime.of(18, 0),
-            "Test Message",
-            Position.CF,
-            SkillLevel.AMATEUR
-        );
+        testTeam = Fixture.createTeam();
+        // Fixture로 생성한 Team 객체에 ID를 설정해줍니다.
+        // 이 ID는 다른 테스트에서 일관되게 사용됩니다.
+        ReflectionTestUtils.setField(testTeam, "id", 1L);
+
+        testRecruitment = Fixture.createRecruitment(testTeam);
+        createRequest = Fixture.createRecruitmentRequest(testTeam.getTeamId());
     }
 
     @Test
     @DisplayName("용병 모집 공고 생성 - 성공")
     void create_success() {
         // given
-        RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-            1L,
-            LocalDate.now().plusDays(1),
-            LocalTime.of(18, 0),
-            "Test Message",
-            "골키퍼",
-            "아마추어"
-        );
-
-        given(teamRepository.findById(request.teamId())).willReturn(Optional.of(testTeam));
+        given(teamRepository.findById(createRequest.teamId())).willReturn(Optional.of(testTeam));
         given(recruitmentRepository.save(any(MercenaryRecruitment.class))).willReturn(testRecruitment);
 
         // when
-        RecruitmentResponse response = mercenaryRecruitmentService.create(request);
+        RecruitmentResponse response = mercenaryRecruitmentService.create(createRequest);
 
         // then
         assertThat(response).isNotNull();
-        assertThat(response.message()).isEqualTo("Test Message");
-        verify(teamRepository).findById(1L);
+        assertThat(response.message()).isEqualTo(Fixture.MESSAGE);
+        verify(teamRepository).findById(testTeam.getTeamId());
         verify(recruitmentRepository).save(any(MercenaryRecruitment.class));
     }
 
@@ -109,12 +88,12 @@ class MercenaryRecruitmentTest {
     void create_fail_invalidPosition() {
         // given
         RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-            1L,
-            LocalDate.now().plusDays(1),
-            LocalTime.of(18, 0),
-            "Test Message",
+            testTeam.getTeamId(),
+            Fixture.MATCH_DATE,
+            Fixture.MATCH_START_TIME,
+            Fixture.MESSAGE,
             "존재하지 않는 포지션",
-            "아마추어"
+            Fixture.SKILL_LEVEL
         );
 
         given(teamRepository.findById(request.teamId())).willReturn(Optional.of(testTeam));
@@ -128,12 +107,12 @@ class MercenaryRecruitmentTest {
     void create_fail_matchDateInThePast() {
         // given
         RecruitmentCreateRequest request = new RecruitmentCreateRequest(
-            1L,
+            testTeam.getTeamId(),
             LocalDate.now().minusDays(1),
-            LocalTime.of(18, 0),
-            "Test Message",
-            "공격수",
-            "아마추어"
+            Fixture.MATCH_START_TIME,
+            Fixture.MESSAGE,
+            Fixture.POSITION,
+            Fixture.SKILL_LEVEL
         );
 
         given(teamRepository.findById(request.teamId())).willReturn(Optional.of(testTeam));
@@ -146,8 +125,9 @@ class MercenaryRecruitmentTest {
     @DisplayName("용병 모집 공고 생성 - 실패 (팀 없음)")
     void create_fail_teamNotFound() {
         // given
-        RecruitmentCreateRequest request = new RecruitmentCreateRequest(999L, null, null, null, null, null);
-        given(teamRepository.findById(999L)).willReturn(Optional.empty());
+        long nonExistentTeamId = 999L;
+        RecruitmentCreateRequest request = Fixture.createRecruitmentRequest(nonExistentTeamId);
+        given(teamRepository.findById(nonExistentTeamId)).willReturn(Optional.empty());
 
         // when & then
         assertThrows(TeamNotFoundException.class, () -> {
@@ -171,7 +151,7 @@ class MercenaryRecruitmentTest {
         // then
         assertThat(responsePage).isNotNull();
         assertThat(responsePage.getContent()).hasSize(1);
-        assertThat(responsePage.getContent().get(0).message()).isEqualTo("Test Message");
+        assertThat(responsePage.getContent().get(0).message()).isEqualTo(Fixture.MESSAGE);
     }
 
     @Test
@@ -185,7 +165,7 @@ class MercenaryRecruitmentTest {
 
         // then
         assertThat(response).isNotNull();
-        assertThat(response.message()).isEqualTo("Test Message");
+        assertThat(response.message()).isEqualTo(Fixture.MESSAGE);
     }
 
     @Test
@@ -221,5 +201,64 @@ class MercenaryRecruitmentTest {
 
         // then
         verify(recruitmentRepository).deleteById(1L);
+    }
+
+    static class Fixture {
+        // 반복되는 값들은 상수로 만들어 재사용합니다.
+        public static final String MESSAGE = "Test Message";
+        public static final String POSITION = "공격수";
+        public static final String SKILL_LEVEL = "아마추어";
+        public static final LocalDate MATCH_DATE = LocalDate.now().plusDays(1);
+        public static final LocalTime MATCH_START_TIME = LocalTime.of(18, 0);
+
+        // 테스트용 Team 객체를 생성하는 메서드
+        public static Team createTeam() {
+            // ID를 포함한 객체를 생성하기 위해 Reflection을 사용하거나,
+            // ID를 세팅할 수 있는 별도의 생성자나 메서드를 두는 것이 좋습니다.
+            // 여기서는 간단하게 표현합니다.
+            Team team = new Team(
+                "두리FC",
+                User.create(
+                    "김학생",
+                    "student@example.com",
+                    "student@kangwon.ac.kr",
+                    "010-1234-5678",
+                    "강원대학교",
+                    "컴퓨터공학과",
+                    "20",
+                    "안녕하세요!"),
+                "강원대학교",
+                TeamType.CENTRAL_CLUB,
+                SkillLevel.AMATEUR,
+                "즐겜해요~"
+            );
+            // 실제로는 teamId가 필요하므로 setter나 다른 방법으로 ID를 설정해주는 로직이 필요합니다.
+            // 예: ReflectionTestUtils.setField(team, "id", 1L);
+            return team;
+        }
+
+        // 테스트용 MercenaryRecruitment 객체를 생성하는 메서드
+        public static MercenaryRecruitment createRecruitment(Team team) {
+            return MercenaryRecruitment.create(
+                team,
+                MATCH_DATE,
+                MATCH_START_TIME,
+                MESSAGE,
+                Position.valueOf(POSITION),
+                SkillLevel.valueOf(SKILL_LEVEL)
+            );
+        }
+
+        // 테스트용 RecruitmentCreateRequest DTO를 생성하는 메서드
+        public static RecruitmentCreateRequest createRecruitmentRequest(Long teamId) {
+            return new RecruitmentCreateRequest(
+                teamId,
+                MATCH_DATE,
+                MATCH_START_TIME,
+                MESSAGE,
+                POSITION,
+                SKILL_LEVEL
+            );
+        }
     }
 }


### PR DESCRIPTION
# 🔥 Pull Request


## 🛠️ 뭘 했는지
- 피드백 반영 (`MercenaryRecruitmentTest` 테스트 코드 리팩토링)
  - 반복적인 테스트 객체 생성을 제거하기 위해 테스트 픽스처(Test Fixture) 패턴을 도입했습니다.
  - 하드코딩된 값을 Fixture의 상수로 대체했습니다.
---


## ✅ 확인 사항
- [X] 로컬에서 잘 돌아감
- [X] 기존 기능 안 망가뜨림
- [X] 코드 정리함

---

## 👀 특히 봐주세요!
Fixture 내부 클래스를 통해 테스트 데이터 생성을 한 곳으로 모았는데, 이런 방식이 적절한지 확인 부탁드립니다.

---

*PR 확인 부탁드려요! 🙏*