### PR TITLE
feat(team-member)!: 단건/페이징 조회·수정·삭제 추가 및 엔드포인트 members→users 변경

### DIFF
--- a/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
+++ b/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
@@ -2,6 +2,7 @@ package com.shootdoori.match.controller;
 
 import com.shootdoori.match.dto.TeamMemberRequestDto;
 import com.shootdoori.match.dto.TeamMemberResponseDto;
+import com.shootdoori.match.dto.UpdateTeamMemberRequestDto;
 import com.shootdoori.match.service.TeamMemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,13 +45,14 @@ public class TeamMemberController {
             HttpStatus.OK);
     }
 
-    //    @PutMapping("/{memberId}")
-//    public ResponseEntity<Void> update(@PathVariable Long teamId,
-//        @PathVariable Long memberId,
-//        @RequestBody UpdateTeamMemberRequestDto request) {
-//
-//    }
-//
+    @PutMapping("/{userId}")
+    public ResponseEntity<TeamMemberResponseDto> update(@PathVariable Long teamId,
+        @PathVariable Long userId,
+        @RequestBody UpdateTeamMemberRequestDto requestDto) {
+        return new ResponseEntity<>(
+            teamMemberService.update(teamId, userId, requestDto), HttpStatus.OK);
+    }
+
     @DeleteMapping("/{userId}")
     public ResponseEntity<Void> delete(@PathVariable Long teamId,
         @PathVariable Long userId) {

--- a/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
+++ b/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
@@ -5,6 +5,7 @@ import com.shootdoori.match.dto.TeamMemberResponseDto;
 import com.shootdoori.match.service.TeamMemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/teams/{teamId}/members")
+@RequestMapping("/api/teams/{teamId}/users")
 public class TeamMemberController {
 
     private final TeamMemberService  teamMemberService;
@@ -47,9 +48,11 @@ public class TeamMemberController {
 //
 //    }
 //
-//    @DeleteMapping("/{memberId}")
-//    public ResponseEntity<Void> delete(@PathVariable Long teamId,
-//        @PathVariable Long memberId) {
-//
-//    }
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<Void> delete(@PathVariable Long teamId,
+        @PathVariable Long userId) {
+        teamMemberService.delete(teamId, userId);
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
+++ b/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
@@ -35,7 +35,7 @@ public class TeamMemberController {
             HttpStatus.CREATED);
     }
 
-    @GetMapping("/{userId}}")
+    @GetMapping("/{userId}")
     public ResponseEntity<TeamMemberResponseDto> findByTeamIdAndUserId(@PathVariable Long teamId,
         @PathVariable Long userId) {
         return new ResponseEntity<>(teamMemberService.findByTeamIdAndUserId(teamId, userId),

--- a/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
+++ b/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
@@ -6,6 +6,7 @@ import com.shootdoori.match.service.TeamMemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/teams/{teamId}/users")
 public class TeamMemberController {
 
-    private final TeamMemberService  teamMemberService;
+    private final TeamMemberService teamMemberService;
 
     public TeamMemberController(TeamMemberService teamMemberService) {
         this.teamMemberService = teamMemberService;
@@ -35,13 +36,14 @@ public class TeamMemberController {
             HttpStatus.CREATED);
     }
 
-//    @GetMapping("/{memberId}")
-//    public ResponseEntity<TeamMemberResponseDto> findById(@PathVariable Long teamId,
-//        @PathVariable Long memberId) {
-//
-//    }
-//
-//    @PutMapping("/{memberId}")
+    @GetMapping("/{userId}}")
+    public ResponseEntity<TeamMemberResponseDto> findByTeamIdAndUserId(@PathVariable Long teamId,
+        @PathVariable Long userId) {
+        return new ResponseEntity<>(teamMemberService.findByTeamIdAndUserId(teamId, userId),
+            HttpStatus.OK);
+    }
+
+    //    @PutMapping("/{memberId}")
 //    public ResponseEntity<Void> update(@PathVariable Long teamId,
 //        @PathVariable Long memberId,
 //        @RequestBody UpdateTeamMemberRequestDto request) {

--- a/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
+++ b/src/main/java/com/shootdoori/match/controller/TeamMemberController.java
@@ -4,6 +4,7 @@ import com.shootdoori.match.dto.TeamMemberRequestDto;
 import com.shootdoori.match.dto.TeamMemberResponseDto;
 import com.shootdoori.match.dto.UpdateTeamMemberRequestDto;
 import com.shootdoori.match.service.TeamMemberService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,11 +26,6 @@ public class TeamMemberController {
     public TeamMemberController(TeamMemberService teamMemberService) {
         this.teamMemberService = teamMemberService;
     }
-
-//    @GetMapping
-//    public ResponseEntity<List<TeamMemberResponseDto>> findAllByTeamId(@PathVariable Long teamId) {
-//        ...
-//    }
 
     @PostMapping
     public ResponseEntity<TeamMemberResponseDto> create(@PathVariable Long teamId,
@@ -42,6 +39,14 @@ public class TeamMemberController {
     public ResponseEntity<TeamMemberResponseDto> findByTeamIdAndUserId(@PathVariable Long teamId,
         @PathVariable Long userId) {
         return new ResponseEntity<>(teamMemberService.findByTeamIdAndUserId(teamId, userId),
+            HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<TeamMemberResponseDto>> findAllByTeamId(@PathVariable Long teamId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size) {
+        return new ResponseEntity<>(teamMemberService.findAllByTeamId(teamId, page, size),
             HttpStatus.OK);
     }
 

--- a/src/main/java/com/shootdoori/match/dto/TeamMemberMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/TeamMemberMapper.java
@@ -1,0 +1,23 @@
+package com.shootdoori.match.dto;
+
+import com.shootdoori.match.entity.TeamMember;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TeamMemberMapper {
+
+    private TeamMemberMapper() {
+        
+    }
+
+
+    public TeamMemberResponseDto toTeamMemberResponseDto(TeamMember teamMember) {
+        return new TeamMemberResponseDto(teamMember.getId(),
+            teamMember.getUser().getId(),
+            teamMember.getUser().getName(),
+            teamMember.getUser().getEmail(),
+            teamMember.getUser().getPosition().toString(),
+            teamMember.getRole().toString(),
+            teamMember.getJoinedAt());
+    }
+}

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -155,7 +155,7 @@ public class Team {
     }
 
     public void validateCanAcceptNewMember() {
-        if (this.memberCount.count() >= MAX_MEMBER_COUNT) {
+        if (this.memberCount.count() >= MAX_MEMBERS) {
             throw new TeamCapacityExceededException();
         }
     }

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -1,14 +1,14 @@
 package com.shootdoori.match.entity;
 
 import com.shootdoori.match.exception.DifferentUniversityException;
+import com.shootdoori.match.exception.DuplicateMemberException;
 import com.shootdoori.match.exception.TeamCapacityExceededException;
+import com.shootdoori.match.exception.TeamFullException;
 import com.shootdoori.match.value.Description;
 import com.shootdoori.match.value.MemberCount;
 import com.shootdoori.match.value.TeamName;
 import com.shootdoori.match.value.UniversityName;
 import jakarta.persistence.AttributeOverride;
-import com.shootdoori.match.exception.DuplicateMemberException;
-import com.shootdoori.match.exception.TeamFullException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -147,7 +147,7 @@ public class Team {
     public List<TeamMember> getMembers() {
         return members;
     }
-  
+
     public void validateSameUniversity(User user) {
         if (!this.university.equals(user.getUniversity())) {
             throw new DifferentUniversityException();
@@ -189,5 +189,15 @@ public class Team {
         this.university = UniversityName.of(university);
         this.skillLevel = SkillLevel.fromDisplayName(skillLevel);
         this.description = Description.of(description);
+    }
+
+    public boolean hasCaptain() {
+        return members.stream()
+            .anyMatch(m -> m.getRole() == TeamMemberRole.LEADER);
+    }
+
+    public boolean hasViceCaptain() {
+        return members.stream()
+            .anyMatch(m -> m.getRole() == TeamMemberRole.VICE_LEADER);
     }
 }

--- a/src/main/java/com/shootdoori/match/entity/TeamMember.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamMember.java
@@ -1,5 +1,8 @@
 package com.shootdoori.match.entity;
 
+import com.shootdoori.match.dto.UpdateTeamMemberRequestDto;
+import com.shootdoori.match.exception.DuplicateCaptainException;
+import com.shootdoori.match.exception.DuplicateViceCaptainException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -50,7 +53,7 @@ public class TeamMember {
 
     protected TeamMember() {
     }
-  
+
     public TeamMember(Team team, User user, TeamMemberRole role) {
         this.team = team;
         this.user = user;
@@ -93,5 +96,21 @@ public class TeamMember {
 
     public void setTeam(Team team) {
         this.team = team;
+    }
+
+    public void changeRole(Team team, UpdateTeamMemberRequestDto requestDto) {
+        TeamMemberRole newRole = TeamMemberRole.fromDisplayName(requestDto.role());
+
+        if (newRole == TeamMemberRole.LEADER && team.hasCaptain()
+            && this.role != TeamMemberRole.LEADER) {
+            throw new DuplicateCaptainException();
+        }
+
+        if (newRole == TeamMemberRole.VICE_LEADER && team.hasViceCaptain()
+            && this.role != TeamMemberRole.VICE_LEADER) {
+            throw new DuplicateViceCaptainException();
+        }
+
+        this.role = newRole;
     }
 }

--- a/src/main/java/com/shootdoori/match/entity/TeamMember.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamMember.java
@@ -98,8 +98,7 @@ public class TeamMember {
         this.team = team;
     }
 
-    public void changeRole(Team team, UpdateTeamMemberRequestDto requestDto) {
-        TeamMemberRole newRole = TeamMemberRole.fromDisplayName(requestDto.role());
+    public void changeRole(Team team, TeamMemberRole newRole) {
 
         if (newRole == TeamMemberRole.LEADER && team.hasCaptain()
             && this.role != TeamMemberRole.LEADER) {

--- a/src/main/java/com/shootdoori/match/entity/TeamMember.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamMember.java
@@ -1,7 +1,6 @@
 package com.shootdoori.match.entity;
 
 import com.shootdoori.match.dto.UpdateTeamMemberRequestDto;
-import com.shootdoori.match.exception.CannotAbdicateLeadershipException;
 import com.shootdoori.match.exception.DuplicateCaptainException;
 import com.shootdoori.match.exception.DuplicateViceCaptainException;
 import jakarta.persistence.Column;
@@ -101,10 +100,6 @@ public class TeamMember {
 
     public void changeRole(Team team, UpdateTeamMemberRequestDto requestDto) {
         TeamMemberRole newRole = TeamMemberRole.fromDisplayName(requestDto.role());
-
-        if (this.role == TeamMemberRole.LEADER && newRole != TeamMemberRole.MEMBER) {
-            throw new CannotAbdicateLeadershipException();
-        }
 
         if (newRole == TeamMemberRole.LEADER && team.hasCaptain()
             && this.role != TeamMemberRole.LEADER) {

--- a/src/main/java/com/shootdoori/match/entity/TeamMember.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamMember.java
@@ -1,6 +1,7 @@
 package com.shootdoori.match.entity;
 
 import com.shootdoori.match.dto.UpdateTeamMemberRequestDto;
+import com.shootdoori.match.exception.CannotAbdicateLeadershipException;
 import com.shootdoori.match.exception.DuplicateCaptainException;
 import com.shootdoori.match.exception.DuplicateViceCaptainException;
 import jakarta.persistence.Column;
@@ -100,6 +101,10 @@ public class TeamMember {
 
     public void changeRole(Team team, UpdateTeamMemberRequestDto requestDto) {
         TeamMemberRole newRole = TeamMemberRole.fromDisplayName(requestDto.role());
+
+        if (this.role == TeamMemberRole.LEADER && newRole != TeamMemberRole.MEMBER) {
+            throw new CannotAbdicateLeadershipException();
+        }
 
         if (newRole == TeamMemberRole.LEADER && team.hasCaptain()
             && this.role != TeamMemberRole.LEADER) {

--- a/src/main/java/com/shootdoori/match/exception/CannotAbdicateLeadershipException.java
+++ b/src/main/java/com/shootdoori/match/exception/CannotAbdicateLeadershipException.java
@@ -1,0 +1,8 @@
+package com.shootdoori.match.exception;
+
+public class CannotAbdicateLeadershipException extends BusinessException {
+
+    public CannotAbdicateLeadershipException() {
+        super(ErrorCode.CANNOT_ABDICATE_LEADERSHIP);
+    }
+}

--- a/src/main/java/com/shootdoori/match/exception/CannotAbdicateLeadershipException.java
+++ b/src/main/java/com/shootdoori/match/exception/CannotAbdicateLeadershipException.java
@@ -1,8 +1,0 @@
-package com.shootdoori.match.exception;
-
-public class CannotAbdicateLeadershipException extends BusinessException {
-
-    public CannotAbdicateLeadershipException() {
-        super(ErrorCode.CANNOT_ABDICATE_LEADERSHIP);
-    }
-}

--- a/src/main/java/com/shootdoori/match/exception/DuplicateCaptainException.java
+++ b/src/main/java/com/shootdoori/match/exception/DuplicateCaptainException.java
@@ -1,0 +1,12 @@
+package com.shootdoori.match.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class DuplicateCaptainException extends BusinessException {
+
+    public DuplicateCaptainException() {
+        super(ErrorCode.DUPLICATE_CAPTAIN);
+    }
+}

--- a/src/main/java/com/shootdoori/match/exception/DuplicateViceCaptainException.java
+++ b/src/main/java/com/shootdoori/match/exception/DuplicateViceCaptainException.java
@@ -1,0 +1,12 @@
+package com.shootdoori.match.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class DuplicateViceCaptainException extends BusinessException {
+
+    public DuplicateViceCaptainException() {
+        super(ErrorCode.DUPLICATE_VICE_CAPTAIN);
+    }
+}

--- a/src/main/java/com/shootdoori/match/exception/ErrorCode.java
+++ b/src/main/java/com/shootdoori/match/exception/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
     DUPLICATED_USER("이미 존재하는 사용자입니다."),
     TEAM_CAPACITY_EXCEEDED("팀 정원이 가득 찼습니다. (최대 100명)"),
     TEAM_NOT_FOUND("해당 팀을 찾을 수 없습니다."),
-    USER_NOT_FOUND("해당 유저를 찾을 수 없습니다.");
+    USER_NOT_FOUND("해당 유저를 찾을 수 없습니다."),
+    TEAM_MEMBER_NOT_FOUND("해당 팀 멤버를 찾을 수 없습니다.");
 
 
     private final String message;

--- a/src/main/java/com/shootdoori/match/exception/ErrorCode.java
+++ b/src/main/java/com/shootdoori/match/exception/ErrorCode.java
@@ -8,7 +8,9 @@ public enum ErrorCode {
     TEAM_CAPACITY_EXCEEDED("팀 정원이 가득 찼습니다. (최대 100명)"),
     TEAM_NOT_FOUND("해당 팀을 찾을 수 없습니다."),
     USER_NOT_FOUND("해당 유저를 찾을 수 없습니다."),
-    TEAM_MEMBER_NOT_FOUND("해당 팀 멤버를 찾을 수 없습니다.");
+    TEAM_MEMBER_NOT_FOUND("해당 팀 멤버를 찾을 수 없습니다."),
+    DUPLICATE_CAPTAIN("이미 팀에 회장이 존재합니다."),
+    DUPLICATE_VICE_CAPTAIN("이미 팀에 부회장이 존재합니다.");
 
 
     private final String message;

--- a/src/main/java/com/shootdoori/match/exception/ErrorCode.java
+++ b/src/main/java/com/shootdoori/match/exception/ErrorCode.java
@@ -10,8 +10,7 @@ public enum ErrorCode {
     USER_NOT_FOUND("해당 유저를 찾을 수 없습니다."),
     TEAM_MEMBER_NOT_FOUND("해당 팀 멤버를 찾을 수 없습니다."),
     DUPLICATE_CAPTAIN("이미 팀에 회장이 존재합니다."),
-    DUPLICATE_VICE_CAPTAIN("이미 팀에 부회장이 존재합니다."),
-    CANNOT_ABDICATE_LEADERSHIP("리더는 다른 멤버에게 역할을 위임한 후에만 역할을 변경할 수 있습니다.");
+    DUPLICATE_VICE_CAPTAIN("이미 팀에 부회장이 존재합니다.");
 
 
     private final String message;

--- a/src/main/java/com/shootdoori/match/exception/ErrorCode.java
+++ b/src/main/java/com/shootdoori/match/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
     USER_NOT_FOUND("해당 유저를 찾을 수 없습니다."),
     TEAM_MEMBER_NOT_FOUND("해당 팀 멤버를 찾을 수 없습니다."),
     DUPLICATE_CAPTAIN("이미 팀에 회장이 존재합니다."),
-    DUPLICATE_VICE_CAPTAIN("이미 팀에 부회장이 존재합니다.");
+    DUPLICATE_VICE_CAPTAIN("이미 팀에 부회장이 존재합니다."),
+    CANNOT_ABDICATE_LEADERSHIP("리더는 다른 멤버에게 역할을 위임한 후에만 역할을 변경할 수 있습니다.");
 
 
     private final String message;

--- a/src/main/java/com/shootdoori/match/exception/TeamMemberNotFoundException.java
+++ b/src/main/java/com/shootdoori/match/exception/TeamMemberNotFoundException.java
@@ -1,0 +1,12 @@
+package com.shootdoori.match.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class TeamMemberNotFoundException extends BusinessException {
+
+    public TeamMemberNotFoundException() {
+        super(ErrorCode.TEAM_MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
@@ -8,9 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
-    Optional<TeamMember> findByTeamIdAndUserId(Long teamId, Long userId);
+    Optional<TeamMember> findByTeam_TeamIdAndUser_Id(Long teamId, Long userId);
 
-    Page<TeamMember> findAllByTeamId(Long teamId, Pageable pageable);
+    Page<TeamMember> findAllByTeam_TeamId(Long teamId, Pageable pageable);
 
-    public boolean existsByTeamTeamIdAndUserId(Long teamId, Long userId);
+    public boolean existsByTeam_TeamIdAndUser_Id(Long teamId, Long userId);
 }

--- a/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
@@ -2,10 +2,14 @@ package com.shootdoori.match.repository;
 
 import com.shootdoori.match.entity.TeamMember;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     public boolean existsByTeam_IdAndUser_Id(Long teamId, Long userId);
 
     Optional<TeamMember> findByTeamIdAndUserId(Long teamId, Long userId);
+
+    Page<TeamMember> findAllByTeamId(Long teamId, Pageable pageable);
 }

--- a/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
@@ -1,8 +1,11 @@
 package com.shootdoori.match.repository;
 
 import com.shootdoori.match.entity.TeamMember;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     public boolean existsByTeam_IdAndUser_Id(Long teamId, Long userId);
+
+    Optional<TeamMember> findByTeamIdAndUserId(Long teamId, Long userId);
 }

--- a/src/main/java/com/shootdoori/match/service/TeamMemberService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamMemberService.java
@@ -50,7 +50,7 @@ public class TeamMemberService {
         User user = profileRepository.findById(userId).orElseThrow(
             () -> new UserNotFoundException(userId));
 
-        if (teamMemberRepository.existsByTeamTeamIdAndUserId(teamId, userId)) {
+        if (teamMemberRepository.existsByTeam_TeamIdAndUser_Id(teamId, userId)) {
             throw new AlreadyTeamMemberException();
         }
 
@@ -68,7 +68,7 @@ public class TeamMemberService {
 
     @Transactional(readOnly = true)
     public TeamMemberResponseDto findByTeamIdAndUserId(Long teamId, Long userId) {
-        TeamMember teamMember = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+        TeamMember teamMember = teamMemberRepository.findByTeam_TeamIdAndUser_Id(teamId, userId)
             .orElseThrow(() -> new TeamMemberNotFoundException());
 
         return teamMemberMapper.toTeamMemberResponseDto(teamMember);
@@ -78,7 +78,7 @@ public class TeamMemberService {
     public Page<TeamMemberResponseDto> findAllByTeamId(Long teamId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("teamMemberId").ascending());
 
-        Page<TeamMember> teamMemberPage = teamMemberRepository.findAllByTeamId(teamId, pageable);
+        Page<TeamMember> teamMemberPage = teamMemberRepository.findAllByTeam_TeamId(teamId, pageable);
 
         return teamMemberPage.map(teamMemberMapper::toTeamMemberResponseDto);
     }
@@ -88,7 +88,7 @@ public class TeamMemberService {
         Team team = teamRepository.findById(teamId)
             .orElseThrow(() -> new TeamNotFoundException(teamId));
 
-        TeamMember teamMember = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+        TeamMember teamMember = teamMemberRepository.findByTeam_TeamIdAndUser_Id(teamId, userId)
             .orElseThrow(() -> new TeamMemberNotFoundException());
 
         teamMember.changeRole(team, requestDto);
@@ -100,7 +100,7 @@ public class TeamMemberService {
         Team team = teamRepository.findById(teamId)
             .orElseThrow(() -> new TeamNotFoundException(teamId));
 
-        TeamMember teamMember = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+        TeamMember teamMember = teamMemberRepository.findByTeam_TeamIdAndUser_Id(teamId, userId)
             .orElseThrow(() -> new TeamMemberNotFoundException());
 
         team.removeMember(teamMember);

--- a/src/main/java/com/shootdoori/match/service/TeamMemberService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamMemberService.java
@@ -91,7 +91,7 @@ public class TeamMemberService {
         TeamMember teamMember = teamMemberRepository.findByTeam_TeamIdAndUser_Id(teamId, userId)
             .orElseThrow(() -> new TeamMemberNotFoundException());
 
-        teamMember.changeRole(team, requestDto);
+        teamMember.changeRole(team, TeamMemberRole.fromDisplayName(requestDto.role()));
 
         return teamMemberMapper.toTeamMemberResponseDto(teamMember);
     }

--- a/src/main/java/com/shootdoori/match/service/TeamMemberService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamMemberService.java
@@ -3,6 +3,7 @@ package com.shootdoori.match.service;
 import com.shootdoori.match.dto.TeamMemberMapper;
 import com.shootdoori.match.dto.TeamMemberRequestDto;
 import com.shootdoori.match.dto.TeamMemberResponseDto;
+import com.shootdoori.match.dto.UpdateTeamMemberRequestDto;
 import com.shootdoori.match.entity.Team;
 import com.shootdoori.match.entity.TeamMember;
 import com.shootdoori.match.entity.TeamMemberRole;
@@ -65,6 +66,19 @@ public class TeamMemberService {
     public TeamMemberResponseDto findByTeamIdAndUserId(Long teamId, Long userId) {
         TeamMember teamMember = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
             .orElseThrow(() -> new TeamMemberNotFoundException());
+
+        return teamMemberMapper.toTeamMemberResponseDto(teamMember);
+    }
+
+    public TeamMemberResponseDto update(Long teamId, Long userId,
+        UpdateTeamMemberRequestDto requestDto) {
+        Team team = teamRepository.findById(teamId)
+            .orElseThrow(() -> new TeamNotFoundException(teamId));
+
+        TeamMember teamMember = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+            .orElseThrow(() -> new TeamMemberNotFoundException());
+
+        teamMember.changeRole(team, requestDto);
 
         return teamMemberMapper.toTeamMemberResponseDto(teamMember);
     }

--- a/src/main/java/com/shootdoori/match/service/TeamMemberService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamMemberService.java
@@ -7,7 +7,7 @@ import com.shootdoori.match.entity.TeamMember;
 import com.shootdoori.match.entity.TeamMemberRole;
 import com.shootdoori.match.entity.User;
 import com.shootdoori.match.exception.AlreadyTeamMemberException;
-import com.shootdoori.match.exception.DuplicateMemberException;
+import com.shootdoori.match.exception.TeamMemberNotFoundException;
 import com.shootdoori.match.exception.TeamNotFoundException;
 import com.shootdoori.match.exception.UserNotFoundException;
 import com.shootdoori.match.repository.ProfileRepository;
@@ -61,5 +61,15 @@ public class TeamMemberService {
             savedTeamMember.getUser().getPosition().toString(),
             savedTeamMember.getRole().toString(),
             savedTeamMember.getJoinedAt());
+    }
+
+    public void delete(Long teamId, Long userId) {
+        Team team = teamRepository.findById(teamId)
+            .orElseThrow(() -> new TeamNotFoundException(teamId));
+
+        TeamMember teamMember = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+            .orElseThrow(() -> new TeamMemberNotFoundException());
+
+        team.removeMember(teamMember);
     }
 }

--- a/src/main/java/com/shootdoori/match/service/TeamMemberService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamMemberService.java
@@ -15,6 +15,10 @@ import com.shootdoori.match.exception.UserNotFoundException;
 import com.shootdoori.match.repository.ProfileRepository;
 import com.shootdoori.match.repository.TeamMemberRepository;
 import com.shootdoori.match.repository.TeamRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,6 +72,15 @@ public class TeamMemberService {
             .orElseThrow(() -> new TeamMemberNotFoundException());
 
         return teamMemberMapper.toTeamMemberResponseDto(teamMember);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<TeamMemberResponseDto> findAllByTeamId(Long teamId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("teamMemberId").ascending());
+
+        Page<TeamMember> teamMemberPage = teamMemberRepository.findAllByTeamId(teamId, pageable);
+
+        return teamMemberPage.map(teamMemberMapper::toTeamMemberResponseDto);
     }
 
     public TeamMemberResponseDto update(Long teamId, Long userId,

--- a/src/main/java/com/shootdoori/match/service/TeamMemberService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamMemberService.java
@@ -1,5 +1,6 @@
 package com.shootdoori.match.service;
 
+import com.shootdoori.match.dto.TeamMemberMapper;
 import com.shootdoori.match.dto.TeamMemberRequestDto;
 import com.shootdoori.match.dto.TeamMemberResponseDto;
 import com.shootdoori.match.entity.Team;
@@ -23,12 +24,15 @@ public class TeamMemberService {
     private final TeamMemberRepository teamMemberRepository;
     private final TeamRepository teamRepository;
     private final ProfileRepository profileRepository;
+    private final TeamMemberMapper teamMemberMapper;
 
     public TeamMemberService(TeamMemberRepository teamMemberRepository,
-        TeamRepository teamRepository, ProfileRepository profileRepository) {
+        TeamRepository teamRepository, ProfileRepository profileRepository,
+        TeamMemberMapper teamMemberMapper) {
         this.teamMemberRepository = teamMemberRepository;
         this.teamRepository = teamRepository;
         this.profileRepository = profileRepository;
+        this.teamMemberMapper = teamMemberMapper;
     }
 
     public TeamMemberResponseDto create(Long teamId, TeamMemberRequestDto requestDto) {
@@ -54,13 +58,15 @@ public class TeamMemberService {
         TeamMember teamMember = new TeamMember(team, user, teamMemberRole);
         TeamMember savedTeamMember = teamMemberRepository.save(teamMember);
 
-        return new TeamMemberResponseDto(savedTeamMember.getId(),
-            savedTeamMember.getUser().getId(),
-            savedTeamMember.getUser().getName(),
-            savedTeamMember.getUser().getEmail(),
-            savedTeamMember.getUser().getPosition().toString(),
-            savedTeamMember.getRole().toString(),
-            savedTeamMember.getJoinedAt());
+        return teamMemberMapper.toTeamMemberResponseDto(savedTeamMember);
+    }
+
+    @Transactional(readOnly = true)
+    public TeamMemberResponseDto findByTeamIdAndUserId(Long teamId, Long userId) {
+        TeamMember teamMember = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+            .orElseThrow(() -> new TeamMemberNotFoundException());
+
+        return teamMemberMapper.toTeamMemberResponseDto(teamMember);
     }
 
     public void delete(Long teamId, Long userId) {


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지

* 팀 멤버 삭제 기능 구현
* 팀 멤버 단건 조회 기능 추가
* 팀 멤버 페이징 조회 기능 추가
* `TeamMember` → `TeamMemberResponseDto` 변환용 매퍼 빈(`TeamMemberMapper`) 추가
* **엔드포인트 변경**

  * `/api/teams/{teamId}/members` → `/api/teams/{teamId}/users`
* **도메인 검증/예외**

  * `Team.hasCaptain()` / `Team.hasViceCaptain()` 검증 메서드 추가
  * `changeRole()`에서 회장/부회장 중복 지정 시 예외 처리
  * `TeamMemberNotFoundException`, `DuplicateCaptainException`, `DuplicateViceCaptainException` 정의
* JPA 오류 및 오탈자 수정

* `Request Changes` 반영
  * 팀 리더가 위임 없이 역할을 변경하지 못하도록 제한

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감 (실행 확인 완료)
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
- 팀 멤버 JPA 관련 오류 시, 아래 코드를 복붙해주세요!
```
public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {

    Optional<TeamMember> findByTeam_TeamIdAndUser_Id(Long teamId, Long userId);

    Page<TeamMember> findAllByTeam_TeamId(Long teamId, Pageable pageable);

    public boolean existsByTeam_TeamIdAndUser_Id(Long teamId, Long userId);
}
```

---

*PR 확인 부탁드려요! 🙏*