### PR TITLE
feat(profile): 프로필 생성/수정 시 'Position' 및 'SkillLevel' 필드 반영

### DIFF
--- a/src/main/java/com/shootdoori/match/controller/TeamController.java
+++ b/src/main/java/com/shootdoori/match/controller/TeamController.java
@@ -34,18 +34,18 @@ public class TeamController {
         @RequestBody TeamRequestDto requestDto) {
 
         // TODO: JWT 토큰에서 유저 데이터를 가져와 captain 변수에 넣어야 한다.
-        ProfileCreateRequest createRequest = new ProfileCreateRequest(
+        User captain = User.create(
             "김학생",
             "아마추어",
             "student@example.com",
             "student@kangwon.ac.kr",
             "010-1234-5678",
+            "공격수",
             "강원대학교",
             "컴퓨터공학과",
             "20",
             "안녕하세요! 축구를 좋아하는 대학생입니다."
         );
-        User captain = new User(createRequest);
 
         return new ResponseEntity<>(teamService.create(requestDto, captain), HttpStatus.CREATED);
     }

--- a/src/main/java/com/shootdoori/match/dto/ProfileCreateRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileCreateRequest.java
@@ -28,6 +28,10 @@ public record ProfileCreateRequest(
     @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "핸드폰 번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
     String phoneNumber,
 
+    @NotBlank(message = "포지션은 필수 입력 값입니다.")
+    @Size(max = 10)
+    String position,
+
     @NotBlank(message = "대학교 이름은 필수 입력 값입니다.")
     @Size(max = 100, message = "대학교 이름은 100자를 초과할 수 없습니다.")
     String university,

--- a/src/main/java/com/shootdoori/match/dto/ProfileMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileMapper.java
@@ -12,7 +12,14 @@ public class ProfileMapper {
 
         return new ProfileResponse(
             user.getName(),
+            user.getSkillLevel().name(),
+            user.getEmail(),
+            user.getPhoneNumber(),
+            user.getPosition().name(),
             user.getUniversity().name(),
+            user.getDepartment(),
+            user.getStudentYear(),
+            user.getBio(),
             user.getCreatedAt()
         );
     }

--- a/src/main/java/com/shootdoori/match/dto/ProfileResponse.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileResponse.java
@@ -4,7 +4,14 @@ import java.time.LocalDateTime;
 
 public record ProfileResponse(
     String name,
+    String skillLevel,
+    String email,
+    String phoneNumber,
+    String position,
     String university,
+    String department,
+    String studentYear,
+    String bio,
     LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/shootdoori/match/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileUpdateRequest.java
@@ -4,6 +4,15 @@ import jakarta.validation.constraints.Size;
 
 public record ProfileUpdateRequest(
     @Size(min = 2, max = 100, message = "이름은 2자 이상 100자 이하로 입력해주세요.")
-    String name
+    String name,
+
+    @Size(max = 4, message = "스킬 레벨은 4자 이하로 입력해주세요.")
+    String skillLevel,
+
+    @Size(max = 10, message = "포지션은 10자 이하로 입력해주세요.")
+    String position,
+
+    @Size(max = 500, message = "500자 이하로 입력해주세요.")
+    String bio
 ) {
 }

--- a/src/main/java/com/shootdoori/match/entity/User.java
+++ b/src/main/java/com/shootdoori/match/entity/User.java
@@ -68,43 +68,37 @@ public class User {
 
     }
 
-    private User(String name, String email, String universityEmail, String phoneNumber,
-        String university, String department, String studentYear, String bio) {
+    private User(String name, SkillLevel skillLevel, String email, String universityEmail, String phoneNumber,
+        Position position, String university, String department, String studentYear, String bio) {
+        validate(name, skillLevel.getDisplayName(), email, universityEmail, phoneNumber, position.getDisplayName(), university, department, studentYear, bio);
         this.name = name;
+        this.skillLevel = skillLevel;
         this.email = email;
         this.universityEmail = universityEmail;
         this.phoneNumber = phoneNumber;
-        this.position = Position.CF;
+        this.position = position;
         this.university = UniversityName.of(university);
         this.department = department;
         this.studentYear = studentYear;
         this.bio = bio;
     }
 
-    public static User create(String name, String email, String universityEmail, String phoneNumber,
-        String university, String department, String studentYear, String bio) {
-        return new User(name, email, universityEmail, phoneNumber, university, department,
+    public static User create(String name, String skillLevelName, String email, String universityEmail, String phoneNumber,
+                              String positionName, String university, String department, String studentYear, String bio) {
+        Position position = Position.fromDisplayName(positionName);
+        SkillLevel skillLevel = SkillLevel.fromDisplayName(skillLevelName);
+        return new User(name, skillLevel, email, universityEmail, phoneNumber, position, university, department,
             studentYear, bio);
     }
 
-    public User(ProfileCreateRequest createRequest) {
-        this.name = createRequest.name();
-        this.skillLevel = SkillLevel.fromDisplayName(createRequest.skillLevel());
-        this.email = createRequest.email();
-        this.universityEmail = createRequest.universityEmail();
-        this.phoneNumber = createRequest.phoneNumber();
-        this.university = UniversityName.of(createRequest.university());
-        this.department = createRequest.department();
-        this.studentYear = createRequest.studentYear();
-        this.bio = createRequest.bio();
-    }
-
-    private void validate(String name, String email, String universityEmail, String phoneNumber,
-        String university, String department, String studentYear, String bio) {
+    private void validate(String name, String skillLevel, String email, String universityEmail, String phoneNumber,
+        String position, String university, String department, String studentYear, String bio) {
         validateName(name);
+        validateSkillLevel(skillLevel);
         validateEmail(email);
         validateUniversityEmail(universityEmail);
         validatePhoneNumber(phoneNumber);
+        validatePosition(position);
         validateUniversity(university);
         validateDepartment(department);
         validateStudentYear(studentYear);
@@ -120,6 +114,18 @@ public class User {
         }
     }
 
+    private void validateSkillLevel(String skillLevel) {
+        if (skillLevel == null || skillLevel.isBlank()) {
+            throw new IllegalArgumentException("스킬 레벨은 필수 입력 값입니다.");
+        }
+
+        try {
+            SkillLevel.fromDisplayName(skillLevel);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 스킬 레벨입니다: " + skillLevel);
+        }
+    }
+
     private void validateEmail(String email) {
         if (email == null || email.isBlank()) {
             throw new IllegalArgumentException("이메일은 필수 입력 값입니다.");
@@ -127,7 +133,7 @@ public class User {
         if (email.length() > 255) {
             throw new IllegalArgumentException("이메일 주소는 255자를 초과할 수 없습니다.");
         }
-        if (!email.matches("^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$")) {
+        if (!email.matches("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$")) {
             throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
         }
     }
@@ -139,7 +145,7 @@ public class User {
         if (universityEmail.length() > 255) {
             throw new IllegalArgumentException("학교 이메일 주소는 255자를 초과할 수 없습니다.");
         }
-        if (!universityEmail.endsWith(".ac.kr")) {
+        if (!universityEmail.endsWith("ac.kr")) {
             throw new IllegalArgumentException("학교 이메일은 'ac.kr' 도메인이어야 합니다.");
         }
     }
@@ -150,6 +156,18 @@ public class User {
         }
         if (!phoneNumber.matches("^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$")) {
             throw new IllegalArgumentException("핸드폰 번호 형식이 올바르지 않습니다. (예: 010-1234-5678)");
+        }
+    }
+
+    private void validatePosition(String position) {
+        if (position == null || position.isBlank()) {
+            throw new IllegalArgumentException("포지션은 필수 입력 값입니다.");
+        }
+
+        try {
+            Position.fromDisplayName(position);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 포지션입니다: " + position);
         }
     }
 
@@ -194,6 +212,10 @@ public class User {
         return this.name;
     }
 
+    public SkillLevel getSkillLevel() {
+        return this.skillLevel;
+    }
+
     public String getEmail() {
         return this.email;
     }
@@ -234,8 +256,12 @@ public class User {
         return this.updatedAt;
     }
 
-    public void update(ProfileUpdateRequest updateRequest) {
-        validateName(updateRequest.name());
-        this.name = updateRequest.name();
+    public void update(String skillLevel, String position, String bio) {
+        validateSkillLevel(skillLevel);
+        validatePosition(position);
+        validateBio(bio);
+        this.skillLevel = SkillLevel.fromDisplayName(skillLevel);
+        this.position = Position.fromDisplayName(position);
+        this.bio = bio;
     }
 }

--- a/src/main/java/com/shootdoori/match/service/ProfileService.java
+++ b/src/main/java/com/shootdoori/match/service/ProfileService.java
@@ -31,9 +31,11 @@ public class ProfileService {
 
         User user = User.create(
             createRequest.name(),
+            createRequest.skillLevel(),
             createRequest.email(),
             createRequest.universityEmail(),
             createRequest.phoneNumber(),
+            createRequest.position(),
             createRequest.university(),
             createRequest.department(),
             createRequest.studentYear(),
@@ -54,7 +56,7 @@ public class ProfileService {
     public void updateProfile(Long id, ProfileUpdateRequest updateRequest) {
         User profile = profileRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("해당 프로필을 찾을 수 없습니다."));
-        profile.update(updateRequest);
+        profile.update(updateRequest.skillLevel(), updateRequest.position(), updateRequest.bio());
     }
 
     public void deleteProfile(Long id) {

--- a/src/test/java/com/shootdoori/mercenary/MercenaryRecruitmentTest.java
+++ b/src/test/java/com/shootdoori/mercenary/MercenaryRecruitmentTest.java
@@ -54,7 +54,6 @@ class MercenaryRecruitmentTest {
     @BeforeEach
     void setUp() {
         testTeam = Fixture.createTeam();
-        // [수정] Team 엔티티의 ID 필드 이름을 'id'에서 'teamId'로 변경합니다. (가장 가능성 높은 이름)
         ReflectionTestUtils.setField(testTeam, "teamId", 1L);
 
         testRecruitment = Fixture.createRecruitment(testTeam);

--- a/src/test/java/com/shootdoori/mercenary/MercenaryRecruitmentTest.java
+++ b/src/test/java/com/shootdoori/mercenary/MercenaryRecruitmentTest.java
@@ -35,7 +35,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("용병 모집 서비스 단위 테스트")
+@DisplayName("용병 모집 테스트")
 class MercenaryRecruitmentTest {
 
     @InjectMocks
@@ -47,20 +47,15 @@ class MercenaryRecruitmentTest {
     @Mock
     private TeamRepository teamRepository;
 
-    // --- 테스트 픽스처(Test Fixture)로 분리된 객체들 ---
-    // 각 테스트에서 이 객체들을 재사용합니다.
     private Team testTeam;
     private MercenaryRecruitment testRecruitment;
     private RecruitmentCreateRequest createRequest;
 
-    // @BeforeEach: 각 테스트가 실행되기 전에 이 메서드가 호출되어
-    // 항상 깨끗하고 일관된 테스트 환경을 만들어줍니다.
     @BeforeEach
     void setUp() {
         testTeam = Fixture.createTeam();
-        // Fixture로 생성한 Team 객체에 ID를 설정해줍니다.
-        // 이 ID는 다른 테스트에서 일관되게 사용됩니다.
-        ReflectionTestUtils.setField(testTeam, "id", 1L);
+        // [수정] Team 엔티티의 ID 필드 이름을 'id'에서 'teamId'로 변경합니다. (가장 가능성 높은 이름)
+        ReflectionTestUtils.setField(testTeam, "teamId", 1L);
 
         testRecruitment = Fixture.createRecruitment(testTeam);
         createRequest = Fixture.createRecruitmentRequest(testTeam.getTeamId());
@@ -204,52 +199,33 @@ class MercenaryRecruitmentTest {
     }
 
     static class Fixture {
-        // 반복되는 값들은 상수로 만들어 재사용합니다.
         public static final String MESSAGE = "Test Message";
         public static final String POSITION = "공격수";
         public static final String SKILL_LEVEL = "아마추어";
         public static final LocalDate MATCH_DATE = LocalDate.now().plusDays(1);
         public static final LocalTime MATCH_START_TIME = LocalTime.of(18, 0);
 
-        // 테스트용 Team 객체를 생성하는 메서드
         public static Team createTeam() {
-            // ID를 포함한 객체를 생성하기 위해 Reflection을 사용하거나,
-            // ID를 세팅할 수 있는 별도의 생성자나 메서드를 두는 것이 좋습니다.
-            // 여기서는 간단하게 표현합니다.
-            Team team = new Team(
+            return new Team(
                 "두리FC",
                 User.create(
-                    "김학생",
-                    "student@example.com",
-                    "student@kangwon.ac.kr",
-                    "010-1234-5678",
-                    "강원대학교",
-                    "컴퓨터공학과",
-                    "20",
-                    "안녕하세요!"),
-                "강원대학교",
-                TeamType.CENTRAL_CLUB,
-                SkillLevel.AMATEUR,
-                "즐겜해요~"
+                    "김학생", "아마추어", "student@example.com", "student@kangwon.ac.kr",
+                    "010-1234-5678", "공격수", "강원대학교", "컴퓨터공학과", "20", "안녕하세요!"),
+                "강원대학교", TeamType.CENTRAL_CLUB, SkillLevel.AMATEUR, "즐겜해요~"
             );
-            // 실제로는 teamId가 필요하므로 setter나 다른 방법으로 ID를 설정해주는 로직이 필요합니다.
-            // 예: ReflectionTestUtils.setField(team, "id", 1L);
-            return team;
         }
 
-        // 테스트용 MercenaryRecruitment 객체를 생성하는 메서드
         public static MercenaryRecruitment createRecruitment(Team team) {
             return MercenaryRecruitment.create(
                 team,
                 MATCH_DATE,
                 MATCH_START_TIME,
                 MESSAGE,
-                Position.valueOf(POSITION),
-                SkillLevel.valueOf(SKILL_LEVEL)
+                Position.fromDisplayName(POSITION),
+                SkillLevel.fromDisplayName(SKILL_LEVEL)
             );
         }
 
-        // 테스트용 RecruitmentCreateRequest DTO를 생성하는 메서드
         public static RecruitmentCreateRequest createRecruitmentRequest(Long teamId) {
             return new RecruitmentCreateRequest(
                 teamId,

--- a/src/test/java/com/shootdoori/profile/ProfileTest.java
+++ b/src/test/java/com/shootdoori/profile/ProfileTest.java
@@ -1,16 +1,25 @@
 package com.shootdoori.profile;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.shootdoori.match.dto.ProfileCreateRequest;
+import com.shootdoori.match.dto.ProfileMapper;
+import com.shootdoori.match.dto.ProfileResponse;
 import com.shootdoori.match.dto.ProfileUpdateRequest;
+import com.shootdoori.match.entity.Position;
+import com.shootdoori.match.entity.SkillLevel;
 import com.shootdoori.match.entity.User;
 import com.shootdoori.match.exception.DuplicatedUserException;
 import com.shootdoori.match.repository.ProfileRepository;
 import com.shootdoori.match.service.ProfileService;
+import java.time.LocalDateTime;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,59 +33,102 @@ public class ProfileTest {
     @Mock
     private ProfileRepository profileRepository;
 
+    @Mock
+    private ProfileMapper profileMapper;
+
     @InjectMocks
     private ProfileService profileService;
+
+    private User user;
+    private ProfileCreateRequest createRequest;
+    private final Long userId = 1L;
+
+    @BeforeEach
+    void setup() {
+        createRequest = new ProfileCreateRequest(
+            "jam", "아마추어", "test@email.com", "test@ac.kr",
+            "010-0000-0000", "공격수", "knu", "cs",
+            "20", "hello, world"
+        );
+
+        user = User.create(
+            createRequest.name(), createRequest.skillLevel(), createRequest.email(), createRequest.universityEmail(),
+            createRequest.phoneNumber(), createRequest.position(), createRequest.university(),
+            createRequest.department(), createRequest.studentYear(), createRequest.bio()
+        );
+    }
 
     @Test
     @DisplayName("프로필 정보 수정 성공")
     void updateProfile_Success() {
         // given
-        Long userId = 1L;
-        ProfileCreateRequest createRequest = new ProfileCreateRequest(
-            "jam",
-            "test@email.com",
-            "test@email.co.kr",
-            "010-0000-0000",
-            "knu",
-            "cs",
-            "202500000",
-            "hello, world"
-        );
-        User user = new User(createRequest);
-        ProfileUpdateRequest updateRequest = new ProfileUpdateRequest("변경된이름");
-
+        ProfileUpdateRequest updateRequest = new ProfileUpdateRequest("jam", "프로", "골키퍼", "변경된 자기소개");
         when(profileRepository.findById(userId)).thenReturn(Optional.of(user));
 
         // when
         profileService.updateProfile(userId, updateRequest);
 
         // then
-        assertThat(user.getName()).isEqualTo("변경된이름");
+        assertThat(user.getSkillLevel()).isEqualTo(SkillLevel.PRO);
+        assertThat(user.getPosition()).isEqualTo(Position.GK);
+        assertThat(user.getBio()).isEqualTo("변경된 자기소개");
+        assertThat(user.getName()).isEqualTo("jam");
     }
 
     @Test
-    @DisplayName("이미 존재하는 이메일로 프로필 생성 시 DuplicatedDataException 예외 발생")
+    @DisplayName("프로필 생성 성공")
+    void createProfile_Success() {
+        // given
+        when(profileRepository.existsByEmailOrUniversityEmail(createRequest.email(), createRequest.universityEmail()))
+            .thenReturn(false);
+        when(profileRepository.save(any(User.class))).thenReturn(user);
+
+        when(profileMapper.toProfileResponse(user)).thenReturn(
+            new ProfileResponse("jam", "AMATEUR", "test@email.com", "010-0000-0000",
+                "FW", "knu", "cs", "20", "hello, world", LocalDateTime.now())
+        );
+
+        // when
+        ProfileResponse response = profileService.createProfile(createRequest);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.name()).isEqualTo(createRequest.name());
+        assertThat(response.skillLevel()).isEqualTo(SkillLevel.AMATEUR.name());
+        assertThat(response.position()).isEqualTo(Position.FW.name());
+        verify(profileRepository).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("프로필 생성 실패 - 유효하지 않은 포지션")
+    void createProfile_WithInvalidPosition_ThrowsException() {
+        // given
+        ProfileCreateRequest invalidRequest = new ProfileCreateRequest(
+            "jam", "아마추어", "new@email.com", "new@ac.kr",
+            "010-1111-1111", "마법사", "knu", "cs",
+            "20", "hello, world"
+        );
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> profileService.createProfile(invalidRequest));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 이메일로 프로필 생성 시 DuplicatedUserException 예외 발생")
     void createProfile_WithDuplicateEmail_ThrowsException() {
         // given
-        ProfileCreateRequest createRequest = new ProfileCreateRequest(
-            "jam",
-            "duplicate@email.com",
-            "test@email.co.kr",
-            "010-0000-0000",
-            "knu",
-            "cs",
-            "202500000",
-            "hello, world"
+        ProfileCreateRequest duplicateRequest = new ProfileCreateRequest(
+            "jam", "아마추어", "duplicate@email.com", "test@kangwon.ac.kr",
+            "010-0000-0000", "공격수", "knu", "cs",
+            "20", "hello, world"
         );
 
         when(profileRepository.existsByEmailOrUniversityEmail(
-            createRequest.email(),
-            createRequest.universityEmail()
+            duplicateRequest.email(),
+            duplicateRequest.universityEmail()
         )).thenReturn(true);
 
         // when & then
-        assertThrows(DuplicatedUserException.class, () -> {
-            profileService.createProfile(createRequest);
-        });
+        assertThrows(DuplicatedUserException.class, () -> profileService.createProfile(duplicateRequest));
     }
 }


### PR DESCRIPTION
# 🔥 Pull Request

## 🛠️ 뭘 했는지
- User를 생성할 때 position, skillLevel을 받아서 생성하도록 수정했습니다.
- User 정보를 수정할 때 skillLevel, position, bio를 받아서 수정할 수 있도록 했습니다.
- dto, mapper, service, test 파일들을 같이 수정했습니다.
 
---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
request로 "아마추어"/"공격수"와 같이 String으로 받아와서 entity에서 검증 후 "AMATEUR"/"FW" 로 저장합니다.
그리고 response에서 "AMATEUR"/"FW"를 반환하도록 했는데 형식이 맞는지 확인 부탁드립니다.
---

*PR 확인 부탁드려요! 🙏*