### PR TITLE
feat(join-queue): 팀 가입 생성/승인/거절/취소 로직 구현

### DIFF
--- a/src/main/java/com/shootdoori/match/MatchApplication.java
+++ b/src/main/java/com/shootdoori/match/MatchApplication.java
@@ -2,8 +2,10 @@ package com.shootdoori.match;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class MatchApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/shootdoori/match/controller/JoinQueueController.java
+++ b/src/main/java/com/shootdoori/match/controller/JoinQueueController.java
@@ -1,6 +1,7 @@
 package com.shootdoori.match.controller;
 
 import com.shootdoori.match.dto.JoinQueueApproveRequestDto;
+import com.shootdoori.match.dto.JoinQueueCancelRequestDto;
 import com.shootdoori.match.dto.JoinQueueRejectRequestDto;
 import com.shootdoori.match.dto.JoinQueueRequestDto;
 import com.shootdoori.match.dto.JoinQueueResponseDto;
@@ -39,21 +40,31 @@ public class JoinQueueController {
         @PathVariable Long teamId,
         @PathVariable Long joinQueueId,
         @RequestBody JoinQueueApproveRequestDto requestDto
-        // TODO: JWT 구현 이후에 Resolver 활용한 approver User ID 주입 필요 (현재는 JoinQueueApproveRequestDto에 존재)
+        // TODO: JWT 구현 이후에 Resolver 활용한 approver TeamMember ID 주입 필요 (현재는 JoinQueueApproveRequestDto에 존재)
     ) {
         return new ResponseEntity<>(joinQueueService.approve(teamId, joinQueueId, requestDto),
             HttpStatus.OK);
     }
 
-    @Transactional
     @PostMapping("/{joinQueueId}/reject")
     public ResponseEntity<JoinQueueResponseDto> reject(
         @PathVariable Long teamId,
         @PathVariable Long joinQueueId,
         @RequestBody JoinQueueRejectRequestDto requestDto
-        // TODO: JWT 구현 이후에 Resolver 활용한 approver User ID 주입 필요 (현재는 JoinQueueRejectRequestDto에 존재)
+        // TODO: JWT 구현 이후에 Resolver 활용한 approver TeamMember ID 주입 필요 (현재는 JoinQueueRejectRequestDto에 존재)
     ) {
         return new ResponseEntity<>(joinQueueService.reject(teamId, joinQueueId, requestDto),
+            HttpStatus.OK);
+    }
+
+    @PostMapping("/{joinQueueId}/cancel")
+    public ResponseEntity<JoinQueueResponseDto> cancel(
+        @PathVariable Long teamId,
+        @PathVariable Long joinQueueId,
+        @RequestBody JoinQueueCancelRequestDto requestDto
+        // TODO: JWT 구현 이후에 Resolver 활용한 requester User ID 주입 필요 (현재는 JoinQueueCancelRequestDto에 존재)
+    ) {
+        return new ResponseEntity<>(joinQueueService.cancel(teamId, joinQueueId, requestDto),
             HttpStatus.OK);
     }
 }

--- a/src/main/java/com/shootdoori/match/controller/JoinQueueController.java
+++ b/src/main/java/com/shootdoori/match/controller/JoinQueueController.java
@@ -1,5 +1,6 @@
 package com.shootdoori.match.controller;
 
+import com.shootdoori.match.dto.JoinQueueApproveRequestDto;
 import com.shootdoori.match.dto.JoinQueueRequestDto;
 import com.shootdoori.match.dto.JoinQueueResponseDto;
 import com.shootdoori.match.service.JoinQueueService;
@@ -29,5 +30,16 @@ public class JoinQueueController {
     ) {
         return new ResponseEntity<>(joinQueueService.create(teamId, requestDto),
             HttpStatus.CREATED);
+    }
+
+    @PostMapping("/{joinQueueId}/approve")
+    public ResponseEntity<JoinQueueResponseDto> approve(
+        @PathVariable Long teamId,
+        @PathVariable Long joinQueueId,
+        @RequestBody JoinQueueApproveRequestDto requestDto
+        // TODO: JWT 구현 이후에 Resolver 활용한 approver User ID 주입 필요 (현재는 JoinQueueApproveRequestDto에 존재)
+    ) {
+        return new ResponseEntity<>(joinQueueService.approve(teamId, joinQueueId, requestDto),
+            HttpStatus.OK);
     }
 }

--- a/src/main/java/com/shootdoori/match/controller/JoinQueueController.java
+++ b/src/main/java/com/shootdoori/match/controller/JoinQueueController.java
@@ -1,11 +1,13 @@
 package com.shootdoori.match.controller;
 
 import com.shootdoori.match.dto.JoinQueueApproveRequestDto;
+import com.shootdoori.match.dto.JoinQueueRejectRequestDto;
 import com.shootdoori.match.dto.JoinQueueRequestDto;
 import com.shootdoori.match.dto.JoinQueueResponseDto;
 import com.shootdoori.match.service.JoinQueueService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,6 +42,18 @@ public class JoinQueueController {
         // TODO: JWT 구현 이후에 Resolver 활용한 approver User ID 주입 필요 (현재는 JoinQueueApproveRequestDto에 존재)
     ) {
         return new ResponseEntity<>(joinQueueService.approve(teamId, joinQueueId, requestDto),
+            HttpStatus.OK);
+    }
+
+    @Transactional
+    @PostMapping("/{joinQueueId}/reject")
+    public ResponseEntity<JoinQueueResponseDto> reject(
+        @PathVariable Long teamId,
+        @PathVariable Long joinQueueId,
+        @RequestBody JoinQueueRejectRequestDto requestDto
+        // TODO: JWT 구현 이후에 Resolver 활용한 approver User ID 주입 필요 (현재는 JoinQueueRejectRequestDto에 존재)
+    ) {
+        return new ResponseEntity<>(joinQueueService.reject(teamId, joinQueueId, requestDto),
             HttpStatus.OK);
     }
 }

--- a/src/main/java/com/shootdoori/match/controller/JoinQueueController.java
+++ b/src/main/java/com/shootdoori/match/controller/JoinQueueController.java
@@ -1,0 +1,33 @@
+package com.shootdoori.match.controller;
+
+import com.shootdoori.match.dto.JoinQueueRequestDto;
+import com.shootdoori.match.dto.JoinQueueResponseDto;
+import com.shootdoori.match.service.JoinQueueService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/teams/{teamId}/join-queue")
+public class JoinQueueController {
+
+    private final JoinQueueService joinQueueService;
+
+    public JoinQueueController(JoinQueueService joinQueueService) {
+        this.joinQueueService = joinQueueService;
+    }
+
+    @PostMapping
+    public ResponseEntity<JoinQueueResponseDto> create(
+        @PathVariable Long teamId,
+        @RequestBody JoinQueueRequestDto requestDto
+        // TODO: JWT 구현 이후에 Resolver 활용한 유저 ID 주입 필요 (현재는 JoinQueueRequestDto에 존재)
+    ) {
+        return new ResponseEntity<>(joinQueueService.create(teamId, requestDto),
+            HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/shootdoori/match/dto/JoinQueueApproveRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinQueueApproveRequestDto.java
@@ -1,0 +1,8 @@
+package com.shootdoori.match.dto;
+
+public record JoinQueueApproveRequestDto(
+    Long approverId,
+    String role
+) {
+
+}

--- a/src/main/java/com/shootdoori/match/dto/JoinQueueApproveRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinQueueApproveRequestDto.java
@@ -1,8 +1,9 @@
 package com.shootdoori.match.dto;
 
 public record JoinQueueApproveRequestDto(
-    Long approverId,
-    String role
+    Long approverId, // TeamMemberId
+    String role,
+    String decisionReason
 ) {
 
 }

--- a/src/main/java/com/shootdoori/match/dto/JoinQueueCancelRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinQueueCancelRequestDto.java
@@ -1,0 +1,4 @@
+package com.shootdoori.match.dto;
+
+public record JoinQueueCancelRequestDto() {
+}

--- a/src/main/java/com/shootdoori/match/dto/JoinQueueCancelRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinQueueCancelRequestDto.java
@@ -1,4 +1,8 @@
 package com.shootdoori.match.dto;
 
-public record JoinQueueCancelRequestDto() {
+public record JoinQueueCancelRequestDto(
+    Long requesterId, // UserId
+    String decisionReason
+) {
+
 }

--- a/src/main/java/com/shootdoori/match/dto/JoinQueueMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinQueueMapper.java
@@ -1,0 +1,18 @@
+package com.shootdoori.match.dto;
+
+import com.shootdoori.match.entity.JoinQueue;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JoinQueueMapper {
+    public JoinQueueResponseDto toJoinQueueResponseDto(JoinQueue joinQueue) {
+        return new JoinQueueResponseDto(
+            joinQueue.getId(),
+            joinQueue.getTeam().getTeamId(),
+            joinQueue.getApplicant().getId(),
+            joinQueue.getStatus().getDisplayName(),
+            joinQueue.getDecidedBy().toString(),
+            joinQueue.getDecidedAt()
+        );
+    }
+}

--- a/src/main/java/com/shootdoori/match/dto/JoinQueueMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinQueueMapper.java
@@ -11,6 +11,7 @@ public class JoinQueueMapper {
             joinQueue.getTeam().getTeamId(),
             joinQueue.getApplicant().getId(),
             joinQueue.getStatus().getDisplayName(),
+            joinQueue.getDecisionReason(),
             joinQueue.getDecidedBy().toString(),
             joinQueue.getDecidedAt()
         );

--- a/src/main/java/com/shootdoori/match/dto/JoinQueueRejectRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinQueueRejectRequestDto.java
@@ -1,0 +1,8 @@
+package com.shootdoori.match.dto;
+
+public record JoinQueueRejectRequestDto(
+    Long approverId, // TeamMemberId
+    String reason
+) {
+
+}

--- a/src/main/java/com/shootdoori/match/dto/JoinQueueRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinQueueRequestDto.java
@@ -1,0 +1,5 @@
+package com.shootdoori.match.dto;
+
+public record JoinQueueRequestDto(Long applicantId, String message) {
+
+}

--- a/src/main/java/com/shootdoori/match/dto/JoinQueueResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinQueueResponseDto.java
@@ -1,0 +1,8 @@
+package com.shootdoori.match.dto;
+
+import java.time.LocalDateTime;
+
+public record JoinQueueResponseDto(Long id, Long teamId, Long applicantId, String status,
+                                   String decidedBy, LocalDateTime decidedAt) {
+
+}

--- a/src/main/java/com/shootdoori/match/dto/JoinQueueResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinQueueResponseDto.java
@@ -3,6 +3,7 @@ package com.shootdoori.match.dto;
 import java.time.LocalDateTime;
 
 public record JoinQueueResponseDto(Long id, Long teamId, Long applicantId, String status,
-                                   String decidedBy, LocalDateTime decidedAt) {
+                                   String decisionReason, String decidedBy,
+                                   LocalDateTime decidedAt) {
 
 }

--- a/src/main/java/com/shootdoori/match/entity/JoinQueue.java
+++ b/src/main/java/com/shootdoori/match/entity/JoinQueue.java
@@ -50,6 +50,9 @@ public class JoinQueue {
     @Column(name = "message", columnDefinition = "TEXT")
     private String message;
 
+    @Column(name = "decision_reason", columnDefinition = "TEXT")
+    private String decisionReason;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "decided_by")
     private User decidedBy;
@@ -88,6 +91,10 @@ public class JoinQueue {
         return message;
     }
 
+    public String getDecisionReason() {
+        return decisionReason;
+    }
+
     public User getDecidedBy() {
         return decidedBy;
     }
@@ -122,21 +129,23 @@ public class JoinQueue {
         return new JoinQueue(team, applicant, message);
     }
 
-    public void approve(TeamMember approver, TeamMemberRole role) {
+    public void approve(TeamMember approver, TeamMemberRole role, String decisionReason) {
         verifyPending();
         approver.canMakeJoinDecisionFor(this.team);
 
         this.team.recruitMember(this.applicant, role);
         this.status = JoinQueueStatus.APPROVED;
+        this.decisionReason = decisionReason;
         this.decidedBy = approver.getUser();
         this.decidedAt = LocalDateTime.now();
     }
 
-    public void reject(TeamMember approver) {
+    public void reject(TeamMember approver, String decisionReason) {
         verifyPending();
         approver.canMakeJoinDecisionFor(this.team);
 
         this.status = JoinQueueStatus.REJECTED;
+        this.decisionReason = decisionReason;
         this.decidedBy = approver.getUser();
         this.decidedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/shootdoori/match/entity/JoinQueue.java
+++ b/src/main/java/com/shootdoori/match/entity/JoinQueue.java
@@ -68,6 +68,60 @@ public class JoinQueue {
     @Version
     private Long version;
 
+    public Long getId() {
+        return id;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+
+    public User getApplicant() {
+        return applicant;
+    }
+
+    public JoinQueueStatus getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public User getDecidedBy() {
+        return decidedBy;
+    }
+
+    public LocalDateTime getDecidedAt() {
+        return decidedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    protected JoinQueue() {
+
+    }
+
+    public JoinQueue(Team team, User applicant, String message) {
+        this.team = team;
+        this.applicant = applicant;
+        this.message = message;
+    }
+
+    public static JoinQueue create(Team team, User applicant, String message) {
+        return new JoinQueue(team, applicant, message);
+    }
+
     public void approve(TeamMember approver, TeamMemberRole role) {
         verifyPending();
         approver.canMakeJoinDecisionFor(this.team);

--- a/src/main/java/com/shootdoori/match/entity/JoinQueue.java
+++ b/src/main/java/com/shootdoori/match/entity/JoinQueue.java
@@ -150,7 +150,7 @@ public class JoinQueue {
         this.decidedAt = LocalDateTime.now();
     }
 
-    public void cancel(User requester) {
+    public void cancel(User requester, String decisionReason) {
         verifyPending();
 
         if (!requester.equals(this.applicant)) {
@@ -158,6 +158,7 @@ public class JoinQueue {
         }
 
         this.status = JoinQueueStatus.CANCELED;
+        this.decisionReason = decisionReason;
         this.decidedBy = requester;
         this.decidedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/shootdoori/match/entity/JoinQueue.java
+++ b/src/main/java/com/shootdoori/match/entity/JoinQueue.java
@@ -1,0 +1,107 @@
+package com.shootdoori.match.entity;
+
+import com.shootdoori.match.exception.JoinQueueNotPendingException;
+import com.shootdoori.match.exception.NoPermissionException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+    name = "join_queue",
+    indexes = {
+        @Index(name = "idx_join_queue_team_status", columnList = "team_id,status")
+    }
+)
+@EntityListeners(AuditingEntityListener.class)
+public class JoinQueue {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "applicant_id", nullable = false)
+    private User applicant;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private JoinQueueStatus status = JoinQueueStatus.PENDING;
+
+    @Column(name = "message", columnDefinition = "TEXT")
+    private String message;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "decided_by")
+    private User decidedBy;
+
+    @Column(name = "decided_at")
+    private LocalDateTime decidedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Version
+    private Long version;
+
+    public void approve(TeamMember approver, TeamMemberRole role) {
+        verifyPending();
+        approver.canMakeJoinDecisionFor(this.team);
+
+        this.team.recruitMember(this.applicant, role);
+        this.status = JoinQueueStatus.APPROVED;
+        this.decidedBy = approver.getUser();
+        this.decidedAt = LocalDateTime.now();
+    }
+
+    public void reject(TeamMember approver) {
+        verifyPending();
+        approver.canMakeJoinDecisionFor(this.team);
+
+        this.status = JoinQueueStatus.REJECTED;
+        this.decidedBy = approver.getUser();
+        this.decidedAt = LocalDateTime.now();
+    }
+
+    public void cancel(User requester) {
+        verifyPending();
+
+        if (!requester.equals(this.applicant)) {
+            throw new NoPermissionException();
+        }
+
+        this.status = JoinQueueStatus.CANCELED;
+        this.decidedBy = requester;
+        this.decidedAt = LocalDateTime.now();
+    }
+
+    private void verifyPending() {
+        if (!this.status.isPending()) {
+            throw new JoinQueueNotPendingException();
+        }
+    }
+}

--- a/src/main/java/com/shootdoori/match/entity/JoinQueueStatus.java
+++ b/src/main/java/com/shootdoori/match/entity/JoinQueueStatus.java
@@ -1,0 +1,31 @@
+package com.shootdoori.match.entity;
+
+public enum JoinQueueStatus {
+    PENDING("대기중"),
+    APPROVED("승인됨"),
+    REJECTED("거절됨"),
+    CANCELED("취소됨");
+
+    private final String displayName;
+
+    JoinQueueStatus(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public static JoinQueueStatus fromDisplayName(String displayName) {
+        for (JoinQueueStatus status : values()) {
+            if (status.displayName.equals(displayName)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown join queue status: " + displayName);
+    }
+
+    public boolean isPending() {
+        return this == PENDING;
+    }
+}

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -28,6 +28,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Table(name = "team")
@@ -199,5 +200,19 @@ public class Team {
     public boolean hasViceCaptain() {
         return members.stream()
             .anyMatch(m -> m.getRole() == TeamMemberRole.VICE_LEADER);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Team team = (Team) o;
+        return Objects.equals(teamId, team.teamId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(teamId);
     }
 }

--- a/src/main/java/com/shootdoori/match/entity/TeamMember.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamMember.java
@@ -3,6 +3,7 @@ package com.shootdoori.match.entity;
 import com.shootdoori.match.dto.UpdateTeamMemberRequestDto;
 import com.shootdoori.match.exception.DuplicateCaptainException;
 import com.shootdoori.match.exception.DuplicateViceCaptainException;
+import com.shootdoori.match.exception.NoPermissionException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -112,5 +113,13 @@ public class TeamMember {
         }
 
         this.role = newRole;
+    }
+
+    public boolean canMakeJoinDecisionFor(Team team) {
+        if (this.team.equals(team) && !this.role.canMakeJoinDecision()) {
+            throw new NoPermissionException();
+        }
+
+        return true;
     }
 }

--- a/src/main/java/com/shootdoori/match/entity/TeamMember.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamMember.java
@@ -116,7 +116,7 @@ public class TeamMember {
     }
 
     public boolean canMakeJoinDecisionFor(Team team) {
-        if (this.team.equals(team) && !this.role.canMakeJoinDecision()) {
+        if (!this.team.equals(team) || !this.role.canMakeJoinDecision()) {
             throw new NoPermissionException();
         }
 

--- a/src/main/java/com/shootdoori/match/entity/TeamMemberRole.java
+++ b/src/main/java/com/shootdoori/match/entity/TeamMemberRole.java
@@ -23,4 +23,8 @@ public enum TeamMemberRole {
         }
         throw new IllegalArgumentException("Unknown role: " + displayName);
     }
+
+    public boolean canMakeJoinDecision() {
+        return this == LEADER || this == VICE_LEADER;
+    }
 }

--- a/src/main/java/com/shootdoori/match/entity/User.java
+++ b/src/main/java/com/shootdoori/match/entity/User.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -237,5 +238,19 @@ public class User {
     public void update(ProfileUpdateRequest updateRequest) {
         validateName(updateRequest.name());
         this.name = updateRequest.name();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }

--- a/src/main/java/com/shootdoori/match/exception/DuplicatePendingJoinQueueException.java
+++ b/src/main/java/com/shootdoori/match/exception/DuplicatePendingJoinQueueException.java
@@ -1,0 +1,8 @@
+package com.shootdoori.match.exception;
+
+public class DuplicatePendingJoinQueueException extends BusinessException {
+
+    public DuplicatePendingJoinQueueException() {
+        super(ErrorCode.JOIN_QUEUE_ALREADY_PENDING);
+    }
+}

--- a/src/main/java/com/shootdoori/match/exception/ErrorCode.java
+++ b/src/main/java/com/shootdoori/match/exception/ErrorCode.java
@@ -10,7 +10,14 @@ public enum ErrorCode {
     USER_NOT_FOUND("해당 유저를 찾을 수 없습니다."),
     TEAM_MEMBER_NOT_FOUND("해당 팀 멤버를 찾을 수 없습니다."),
     DUPLICATE_CAPTAIN("이미 팀에 회장이 존재합니다."),
-    DUPLICATE_VICE_CAPTAIN("이미 팀에 부회장이 존재합니다.");
+    DUPLICATE_VICE_CAPTAIN("이미 팀에 부회장이 존재합니다."),
+
+    JOIN_QUEUE_NOT_PENDING("대기중 상태의 신청만 처리할 수 있습니다."),
+    JOIN_QUEUE_INVALID_TRANSITION("현재 상태에서 요청된 상태로 변경할 수 없습니다."),
+    JOIN_QUEUE_ALREADY_PENDING("이미 대기중인 신청이 존재합니다."),
+    JOIN_QUEUE_NOT_FOUND("해당 가입 신청을 찾을 수 없습니다."),
+
+    NO_PERMISSION("허락되지 않은 요청입니다.");
 
 
     private final String message;

--- a/src/main/java/com/shootdoori/match/exception/JoinQueueNotFoundException.java
+++ b/src/main/java/com/shootdoori/match/exception/JoinQueueNotFoundException.java
@@ -1,0 +1,7 @@
+package com.shootdoori.match.exception;
+
+public class JoinQueueNotFoundException extends BusinessException {
+  public JoinQueueNotFoundException() {
+    super(ErrorCode.JOIN_QUEUE_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/shootdoori/match/exception/JoinQueueNotPendingException.java
+++ b/src/main/java/com/shootdoori/match/exception/JoinQueueNotPendingException.java
@@ -1,0 +1,12 @@
+package com.shootdoori.match.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class JoinQueueNotPendingException extends BusinessException {
+    public JoinQueueNotPendingException() {
+        super(ErrorCode.JOIN_QUEUE_NOT_PENDING);
+    }
+}
+

--- a/src/main/java/com/shootdoori/match/exception/NoPermissionException.java
+++ b/src/main/java/com/shootdoori/match/exception/NoPermissionException.java
@@ -1,0 +1,12 @@
+package com.shootdoori.match.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class NoPermissionException extends BusinessException {
+
+    public NoPermissionException() {
+        super(ErrorCode.NO_PERMISSION);
+    }
+}

--- a/src/main/java/com/shootdoori/match/repository/JoinQueueRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/JoinQueueRepository.java
@@ -1,0 +1,11 @@
+package com.shootdoori.match.repository;
+
+import com.shootdoori.match.entity.JoinQueue;
+import com.shootdoori.match.entity.JoinQueueStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JoinQueueRepository extends JpaRepository<JoinQueue, Long> {
+
+    boolean existsByTeam_TeamIdAndApplicant_IdAndStatus(Long teamId, Long applicantId,
+        JoinQueueStatus joinQueueStatus);
+}

--- a/src/main/java/com/shootdoori/match/repository/JoinQueueRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/JoinQueueRepository.java
@@ -2,10 +2,23 @@ package com.shootdoori.match.repository;
 
 import com.shootdoori.match.entity.JoinQueue;
 import com.shootdoori.match.entity.JoinQueueStatus;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JoinQueueRepository extends JpaRepository<JoinQueue, Long> {
 
     boolean existsByTeam_TeamIdAndApplicant_IdAndStatus(Long teamId, Long applicantId,
         JoinQueueStatus joinQueueStatus);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+          select j from JoinQueue j
+          join fetch j.team t
+          join fetch j.applicant a
+          where j.id = :id and t.teamId = :teamId
+        """)
+    Optional<JoinQueue> findByIdAndTeam_TeamIdForUpdate(Long id, Long teamId);
 }

--- a/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
@@ -13,4 +13,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     Page<TeamMember> findAllByTeam_TeamId(Long teamId, Pageable pageable);
 
     public boolean existsByTeam_TeamIdAndUser_Id(Long teamId, Long userId);
+
+    Optional<TeamMember> findByIdAndTeam_TeamId(Long teamMemberId, Long teamId);
 }

--- a/src/main/java/com/shootdoori/match/service/JoinQueueService.java
+++ b/src/main/java/com/shootdoori/match/service/JoinQueueService.java
@@ -1,6 +1,7 @@
 package com.shootdoori.match.service;
 
 import com.shootdoori.match.dto.JoinQueueApproveRequestDto;
+import com.shootdoori.match.dto.JoinQueueCancelRequestDto;
 import com.shootdoori.match.dto.JoinQueueMapper;
 import com.shootdoori.match.dto.JoinQueueRejectRequestDto;
 import com.shootdoori.match.dto.JoinQueueRequestDto;
@@ -21,11 +22,8 @@ import com.shootdoori.match.repository.JoinQueueRepository;
 import com.shootdoori.match.repository.ProfileRepository;
 import com.shootdoori.match.repository.TeamMemberRepository;
 import com.shootdoori.match.repository.TeamRepository;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 
 @Service
 public class JoinQueueService {
@@ -103,7 +101,8 @@ public class JoinQueueService {
     }
 
     @Transactional
-    public JoinQueueResponseDto reject(Long teamId, Long joinQueueId, JoinQueueRejectRequestDto requestDto) {
+    public JoinQueueResponseDto reject(Long teamId, Long joinQueueId,
+        JoinQueueRejectRequestDto requestDto) {
 
         Long approverId = requestDto.approverId();
         TeamMember approver = teamMemberRepository.findByIdAndTeam_TeamId(approverId, teamId)
@@ -117,6 +116,22 @@ public class JoinQueueService {
         User applicant = joinQueue.getApplicant();
 
         joinQueue.reject(approver, requestDto.reason());
+
+        return joinQueueMapper.toJoinQueueResponseDto(joinQueue);
+    }
+
+    @Transactional
+    public JoinQueueResponseDto cancel(Long teamId, Long joinQueueId,
+        JoinQueueCancelRequestDto requestDto) {
+
+        Long requesterId = requestDto.requesterId();
+        User requester = profileRepository.findById(requesterId)
+            .orElseThrow(() -> new UserNotFoundException(requesterId));
+
+        JoinQueue joinQueue = joinQueueRepository.findByIdAndTeam_TeamIdForUpdate(joinQueueId, teamId)
+            .orElseThrow(() -> new JoinQueueNotFoundException());
+
+        joinQueue.cancel(requester, requestDto.decisionReason());
 
         return joinQueueMapper.toJoinQueueResponseDto(joinQueue);
     }

--- a/src/main/java/com/shootdoori/match/service/JoinQueueService.java
+++ b/src/main/java/com/shootdoori/match/service/JoinQueueService.java
@@ -1,0 +1,67 @@
+package com.shootdoori.match.service;
+
+import com.shootdoori.match.dto.JoinQueueMapper;
+import com.shootdoori.match.dto.JoinQueueRequestDto;
+import com.shootdoori.match.dto.JoinQueueResponseDto;
+import com.shootdoori.match.entity.JoinQueue;
+import com.shootdoori.match.entity.JoinQueueStatus;
+import com.shootdoori.match.entity.Team;
+import com.shootdoori.match.entity.User;
+import com.shootdoori.match.exception.AlreadyTeamMemberException;
+import com.shootdoori.match.exception.DuplicatePendingJoinQueueException;
+import com.shootdoori.match.exception.TeamNotFoundException;
+import com.shootdoori.match.exception.UserNotFoundException;
+import com.shootdoori.match.repository.JoinQueueRepository;
+import com.shootdoori.match.repository.ProfileRepository;
+import com.shootdoori.match.repository.TeamMemberRepository;
+import com.shootdoori.match.repository.TeamRepository;
+import java.util.Queue;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class JoinQueueService {
+
+    private final ProfileRepository profileRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final JoinQueueRepository joinQueueRepository;
+    private final JoinQueueMapper joinQueueMapper;
+
+    public JoinQueueService(ProfileRepository profileRepository, TeamRepository teamRepository,
+        TeamMemberRepository teamMemberRepository,
+        JoinQueueRepository joinQueueRepository, JoinQueueMapper joinQueueMapper) {
+        this.profileRepository = profileRepository;
+        this.teamRepository = teamRepository;
+        this.teamMemberRepository = teamMemberRepository;
+        this.joinQueueRepository = joinQueueRepository;
+        this.joinQueueMapper = joinQueueMapper;
+    }
+
+    @Transactional
+    public JoinQueueResponseDto create(Long teamId, JoinQueueRequestDto requestDto) {
+        Team team = teamRepository.findById(teamId)
+            .orElseThrow(() -> new TeamNotFoundException(teamId));
+
+        Long applicantId = requestDto.applicantId();
+        User applicant = profileRepository.findById(applicantId)
+            .orElseThrow(() -> new UserNotFoundException(applicantId));
+
+        team.validateSameUniversity(applicant);
+
+        if (teamMemberRepository.existsByTeam_TeamIdAndUser_Id(teamId, applicantId)) {
+            throw new AlreadyTeamMemberException();
+        }
+
+        if (joinQueueRepository.existsByTeam_TeamIdAndApplicant_IdAndStatus(teamId, applicantId,
+            JoinQueueStatus.PENDING)) {
+            throw new DuplicatePendingJoinQueueException();
+        }
+
+        JoinQueue joinQueue = JoinQueue.create(team, applicant, requestDto.message());
+
+        JoinQueue savedJoinQueue = joinQueueRepository.save(joinQueue);
+
+        return joinQueueMapper.toJoinQueueResponseDto(savedJoinQueue);
+    }
+}


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지
1. JoinQueue Entity 추가
    - JoinQueue에 편의 메소드 approve/reject/cancel 추가
    - JoinQueueStatus enum 추가
    - JoinQueueNotPendingException, NoPermissionException 예외 추가
    - User, Team Entity에 equals, hashcode 메소드 overwriting

2. 팀 가입 요청 생성 기능
     - Service: create()
      - JoinQueueRequestDto/ResponseDto 정의
      - JoinQueueService.create 도메인 검증(학교 동일, 기존 멤버 여부, PENDING 중복 신청 방지)
      - JoinQueueRepository.existsByTeam_TeamIdAndApplicant_IdAndStatus 추가
      - JoinQueueMapper: JoinQueue → JoinQueueResponseDto 변환

4. 팀 멤버 요청 승인 기능 추가
    - Service: approve()
      - TeamMemberRole.fromDisplayName(role) 파싱
      - 승인자 조회 시 팀 경계 보장: teamMemberRepository.findByIdAndTeam_TeamId(approverId, teamId)
      - 승인 대상 조회 + 동시성 잠금: joinQueueRepository.findByIdAndTeam_TeamIdForUpdate(joinQueueId, teamId)
      - 승인 시점 재검증: 동일대학, 정원 확인, 기존 멤버 중복 방지(existsByTeam_IdAndUser_Id)
      - 도메인 전이: joinQueue.approve(approver, role, decisionReason) → APPROVED/decisionReason/decidedBy/decidedAt 세팅
      - 응답: JoinQueueResponseDto 매핑
    - Repository:
      - `@lock`(PESSIMISTIC_WRITE) + 팀 경계 쿼리(findByIdAndTeam_TeamIdForUpdate)
      - TeamMemberRepository.findByIdAndTeam_TeamId 추가
      - existsByTeam_IdAndUser_Id 활용

5. 팀 멤버 요청 거절 기능 추가 (승인에서 크게 달라지지 X)
     - Service: reject()
       - DTO: JoinQueueRejectRequestDto.reason 추가
       - DTO: JoinQueueApproveRequestDto.reason 추가 (선택/필수 여부 명시)

6. 팀 멤버 요청 취소 기능 추가
     - Service: cancel()
       - requester의 id가 팀 멤버 요청에 올린 User ID가 같은지도 확인

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감 (실행 가능)
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
- 동시성 문제가 제일 걱정입니다. 비관적 락을 걸어놨으나, 논리적으로 구멍이 있을 것 같아 봐주시면 좋을 것 같습니다.
- 팀 멤버 승인이 주로 검증 로직이 많습니다. 이를 집중적으로 보면 좋을 것 같습니다.

---

*PR 확인 부탁드려요! 🙏*