### PR TITLE
feat: 로그인 및 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	runtimeOnly 'com.h2database:h2'
 //	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	// --- 테스트용 ---
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/shootdoori/match/config/SecurityConfig.java
+++ b/src/main/java/com/shootdoori/match/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.shootdoori.match.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/com/shootdoori/match/config/SecurityConfig.java
+++ b/src/main/java/com/shootdoori/match/config/SecurityConfig.java
@@ -2,11 +2,30 @@ package com.shootdoori.match.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .httpBasic(config -> config.disable())
+            .csrf(config -> config.disable())
+            .sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers("/api/auth/**").permitAll()
+                .anyRequest().authenticated()
+            );
+
+        // TODO: 나중에 JWT 필터 추가
+
+        return http.build();
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/shootdoori/match/config/WebConfig.java
+++ b/src/main/java/com/shootdoori/match/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.shootdoori.match.config;
+
+import com.shootdoori.match.resolver.LoginUserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    public WebConfig(LoginUserArgumentResolver loginUserArgumentResolver) {
+        this.loginUserArgumentResolver = loginUserArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/shootdoori/match/controller/LoginController.java
+++ b/src/main/java/com/shootdoori/match/controller/LoginController.java
@@ -1,0 +1,41 @@
+package com.shootdoori.match.controller;
+
+import com.shootdoori.match.dto.AuthToken;
+import com.shootdoori.match.dto.LoginRequest;
+import com.shootdoori.match.dto.ProfileCreateRequest;
+import com.shootdoori.match.service.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+public class LoginController {
+    private final AuthService authService;
+
+    public LoginController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthToken> login(@RequestBody LoginRequest loginRequest) {
+        AuthToken token = authService.login(loginRequest);
+
+//        // Refresh Token은 HttpOnly 쿠키에 담아 응답
+//        Cookie cookie = new Cookie("refreshToken", token.getRefreshToken());
+//        cookie.setHttpOnly(true);
+//        cookie.setSecure(true); // HTTPS 환경에서만 사용
+//        cookie.setPath("/");
+//        cookie.setMaxAge(....);
+//        response.addCookie(cookie);
+
+        return ResponseEntity.ok(token);
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthToken> register(@RequestBody ProfileCreateRequest profileCreateRequest) {
+        AuthToken token = authService.register(profileCreateRequest);
+        return ResponseEntity.ok(token);
+    }
+}

--- a/src/main/java/com/shootdoori/match/controller/LoginUser.java
+++ b/src/main/java/com/shootdoori/match/controller/LoginUser.java
@@ -1,0 +1,11 @@
+package com.shootdoori.match.controller;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}

--- a/src/main/java/com/shootdoori/match/controller/TeamController.java
+++ b/src/main/java/com/shootdoori/match/controller/TeamController.java
@@ -39,6 +39,7 @@ public class TeamController {
             "아마추어",
             "student@example.com",
             "student@kangwon.ac.kr",
+            "asdf",
             "010-1234-5678",
             "공격수",
             "강원대학교",

--- a/src/main/java/com/shootdoori/match/dto/AuthToken.java
+++ b/src/main/java/com/shootdoori/match/dto/AuthToken.java
@@ -1,0 +1,4 @@
+package com.shootdoori.match.dto;
+
+public record AuthToken(String accessToken) {
+}

--- a/src/main/java/com/shootdoori/match/dto/LoginRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/LoginRequest.java
@@ -1,0 +1,21 @@
+package com.shootdoori.match.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record LoginRequest(
+    @NotBlank(message = "이메일을 반드시 입력해야 합니다.")
+    @Size(max = 50, message = "이메일은 최대 50자까지 입력 가능합니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.") String email,
+
+    @NotBlank(message = "비밀번호를 반드시 입력해야 합니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
+        message = "비밀번호는 영문, 숫자, 특수문자(@$!%*#?&)를 모두 포함해야 합니다."
+    )
+    String password
+) {
+}

--- a/src/main/java/com/shootdoori/match/dto/ProfileCreateRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/ProfileCreateRequest.java
@@ -24,6 +24,11 @@ public record ProfileCreateRequest(
     @Size(max = 255, message = "학교 이메일 주소는 255자를 초과할 수 없습니다.")
     String universityEmail,
 
+    @NotBlank @Size(min = 8, max = 20) @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
+        message = "비밀번호는 8자 이상 20자 이하로 영문, 숫자, 특수문자를 포함해야 합니다."
+    ) String password,
+    
     @NotBlank(message = "핸드폰 번호는 필수 입력 값입니다.")
     @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "핸드폰 번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
     String phoneNumber,

--- a/src/main/java/com/shootdoori/match/entity/User.java
+++ b/src/main/java/com/shootdoori/match/entity/User.java
@@ -1,20 +1,15 @@
 package com.shootdoori.match.entity;
 
-import com.shootdoori.match.dto.ProfileCreateRequest;
-import com.shootdoori.match.dto.ProfileUpdateRequest;
 import com.shootdoori.match.value.UniversityName;
-import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
 
 @Entity
 public class User {
@@ -35,6 +30,9 @@ public class User {
 
     @Column(name = "university_email", nullable = false, unique = true, length = 255)
     private String universityEmail;
+
+    @Column(nullable = false)
+    private String password;
 
     @Column(name = "phone_number", nullable = false, unique = true, length = 13)
     private String phoneNumber;
@@ -68,13 +66,14 @@ public class User {
 
     }
 
-    private User(String name, SkillLevel skillLevel, String email, String universityEmail, String phoneNumber,
+    private User(String name, SkillLevel skillLevel, String email, String universityEmail, String password, String phoneNumber,
         Position position, String university, String department, String studentYear, String bio) {
         validate(name, skillLevel.getDisplayName(), email, universityEmail, phoneNumber, position.getDisplayName(), university, department, studentYear, bio);
         this.name = name;
         this.skillLevel = skillLevel;
         this.email = email;
         this.universityEmail = universityEmail;
+        this.password = password;
         this.phoneNumber = phoneNumber;
         this.position = position;
         this.university = UniversityName.of(university);
@@ -83,11 +82,11 @@ public class User {
         this.bio = bio;
     }
 
-    public static User create(String name, String skillLevelName, String email, String universityEmail, String phoneNumber,
+    public static User create(String name, String skillLevelName, String email, String universityEmail, String encodedPassword, String phoneNumber,
                               String positionName, String university, String department, String studentYear, String bio) {
         Position position = Position.fromDisplayName(positionName);
         SkillLevel skillLevel = SkillLevel.fromDisplayName(skillLevelName);
-        return new User(name, skillLevel, email, universityEmail, phoneNumber, position, university, department,
+        return new User(name, skillLevel, email, universityEmail, encodedPassword, phoneNumber, position, university, department,
             studentYear, bio);
     }
 
@@ -263,5 +262,11 @@ public class User {
         this.skillLevel = SkillLevel.fromDisplayName(skillLevel);
         this.position = Position.fromDisplayName(position);
         this.bio = bio;
+    }
+
+    public void samePassword(String rawPassword, PasswordEncoder passwordEncoder) {
+        if (!passwordEncoder.matches(rawPassword, this.password)) {
+            throw new RuntimeException("이메일 또는 비밀번호가 일치하지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/shootdoori/match/entity/User.java
+++ b/src/main/java/com/shootdoori/match/entity/User.java
@@ -68,7 +68,7 @@ public class User {
 
     private User(String name, SkillLevel skillLevel, String email, String universityEmail, String password, String phoneNumber,
         Position position, String university, String department, String studentYear, String bio) {
-        validate(name, skillLevel.getDisplayName(), email, universityEmail, phoneNumber, position.getDisplayName(), university, department, studentYear, bio);
+        validate(name, skillLevel.getDisplayName(), email, universityEmail, password, phoneNumber, position.getDisplayName(), university, department, studentYear, bio);
         this.name = name;
         this.skillLevel = skillLevel;
         this.email = email;
@@ -90,12 +90,13 @@ public class User {
             studentYear, bio);
     }
 
-    private void validate(String name, String skillLevel, String email, String universityEmail, String phoneNumber,
+    private void validate(String name, String skillLevel, String email, String universityEmail, String password, String phoneNumber,
         String position, String university, String department, String studentYear, String bio) {
         validateName(name);
         validateSkillLevel(skillLevel);
         validateEmail(email);
         validateUniversityEmail(universityEmail);
+        validatePassword(password);
         validatePhoneNumber(phoneNumber);
         validatePosition(position);
         validateUniversity(university);
@@ -176,6 +177,12 @@ public class User {
         }
         if (university.length() > 100) {
             throw new IllegalArgumentException("대학교 이름은 100자를 초과할 수 없습니다.");
+        }
+    }
+
+    private void validatePassword(String password) {
+        if (password == null || password.isBlank()) {
+            throw new IllegalArgumentException("비밀번호는 필수 입력 값입니다.");
         }
     }
 

--- a/src/main/java/com/shootdoori/match/entity/User.java
+++ b/src/main/java/com/shootdoori/match/entity/User.java
@@ -1,5 +1,6 @@
 package com.shootdoori.match.entity;
 
+import com.shootdoori.match.exception.UnauthorizedException;
 import com.shootdoori.match.value.UniversityName;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -273,7 +274,7 @@ public class User {
 
     public void samePassword(String rawPassword, PasswordEncoder passwordEncoder) {
         if (!passwordEncoder.matches(rawPassword, this.password)) {
-            throw new RuntimeException("이메일 또는 비밀번호가 일치하지 않습니다.");
+            throw new UnauthorizedException("잘못된 이메일 또는 비밀번호입니다.");
         }
     }
 }

--- a/src/main/java/com/shootdoori/match/exception/UnauthorizedException.java
+++ b/src/main/java/com/shootdoori/match/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.shootdoori.match.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/shootdoori/match/repository/ProfileRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/ProfileRepository.java
@@ -3,6 +3,10 @@ package com.shootdoori.match.repository;
 import com.shootdoori.match.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ProfileRepository extends JpaRepository<User, Long> {
     boolean existsByEmailOrUniversityEmail(String email, String universityEmail);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/shootdoori/match/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/shootdoori/match/resolver/LoginUserArgumentResolver.java
@@ -1,0 +1,53 @@
+package com.shootdoori.match.resolver;
+
+import com.shootdoori.match.controller.LoginUser;
+import com.shootdoori.match.entity.User;
+import com.shootdoori.match.exception.UnauthorizedException;
+import com.shootdoori.match.repository.ProfileRepository;
+import com.shootdoori.match.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+    private final ProfileRepository profileRepository;
+    private final JwtUtil jwtUtil;
+
+    public LoginUserArgumentResolver(final ProfileRepository profileRepository, final JwtUtil jwtUtil) {
+        this.profileRepository = profileRepository;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUser.class) &&
+            parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+        MethodParameter parameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory
+    ) throws Exception {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String token = jwtUtil.extractToken(request);
+
+        if (token == null || !jwtUtil.validateToken(token)) {
+            throw new UnauthorizedException("인증 토큰이 존재하지 않습니다.");
+        }
+
+        Claims claims = jwtUtil.getClaims(token);
+        Long userId = Long.valueOf(claims.getSubject());
+
+        return profileRepository.findById(userId)
+            .orElseThrow(() -> new UnauthorizedException("토큰에 해당하는 사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/shootdoori/match/service/AuthService.java
+++ b/src/main/java/com/shootdoori/match/service/AuthService.java
@@ -1,0 +1,44 @@
+package com.shootdoori.match.service;
+
+import com.shootdoori.match.dto.AuthToken;
+import com.shootdoori.match.dto.LoginRequest;
+import com.shootdoori.match.dto.ProfileCreateRequest;
+import com.shootdoori.match.entity.User;
+import com.shootdoori.match.util.JwtUtil;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuthService {
+    private final JwtUtil jwtUtil;
+    private final ProfileService profileService;
+    private final PasswordEncoder passwordEncoder;
+
+    public AuthService(JwtUtil jwtUtil, ProfileService profileService, PasswordEncoder passwordEncoder) {
+        this.jwtUtil = jwtUtil;
+        this.profileService = profileService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    public AuthToken register(ProfileCreateRequest request) {
+        profileService.createProfile(request);
+
+        User savedUser = profileService.findByEmail(request.email())
+            .orElseThrow(() -> new RuntimeException("회원가입에 실패하였습니다."));
+
+        return new AuthToken(jwtUtil.generateAccessToken(savedUser));
+    }
+
+    @Transactional(readOnly = true)
+    public AuthToken login(LoginRequest request) {
+        User user = profileService.findByEmail(request.email())
+            .orElseThrow(() -> new RuntimeException("잘못된 이메일 또는 비밀번호입니다."));
+
+        user.samePassword(request.password(), passwordEncoder);
+        String accessToken = jwtUtil.generateAccessToken(user);
+
+        return new AuthToken(accessToken);
+    }
+}

--- a/src/main/java/com/shootdoori/match/service/AuthService.java
+++ b/src/main/java/com/shootdoori/match/service/AuthService.java
@@ -4,6 +4,7 @@ import com.shootdoori.match.dto.AuthToken;
 import com.shootdoori.match.dto.LoginRequest;
 import com.shootdoori.match.dto.ProfileCreateRequest;
 import com.shootdoori.match.entity.User;
+import com.shootdoori.match.exception.UnauthorizedException;
 import com.shootdoori.match.util.JwtUtil;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,7 @@ public class AuthService {
         profileService.createProfile(request);
 
         User savedUser = profileService.findByEmail(request.email())
-            .orElseThrow(() -> new RuntimeException("회원가입에 실패하였습니다."));
+            .orElseThrow(() -> new UnauthorizedException("회원가입에 실패하였습니다."));
 
         return new AuthToken(jwtUtil.generateAccessToken(savedUser));
     }
@@ -34,7 +35,7 @@ public class AuthService {
     @Transactional(readOnly = true)
     public AuthToken login(LoginRequest request) {
         User user = profileService.findByEmail(request.email())
-            .orElseThrow(() -> new RuntimeException("잘못된 이메일 또는 비밀번호입니다."));
+            .orElseThrow(() -> new UnauthorizedException("잘못된 이메일 또는 비밀번호입니다."));
 
         user.samePassword(request.password(), passwordEncoder);
         String accessToken = jwtUtil.generateAccessToken(user);

--- a/src/main/java/com/shootdoori/match/util/JwtSecretGenerator.java
+++ b/src/main/java/com/shootdoori/match/util/JwtSecretGenerator.java
@@ -1,0 +1,14 @@
+package com.shootdoori.match.util;
+
+import java.util.Base64;
+import java.security.SecureRandom;
+
+public class JwtSecretGenerator {
+    public static void main(String[] args) {
+        SecureRandom random = new SecureRandom();
+        byte[] bytes = new byte[48]; // 48 bytes = 384 bits
+        random.nextBytes(bytes);
+        String secret = Base64.getEncoder().encodeToString(bytes);
+        System.out.println(secret);
+    }
+}

--- a/src/main/java/com/shootdoori/match/util/JwtUtil.java
+++ b/src/main/java/com/shootdoori/match/util/JwtUtil.java
@@ -1,0 +1,116 @@
+package com.shootdoori.match.util;
+
+import com.shootdoori.match.entity.User;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class JwtUtil {
+
+    private final Key secretKey;
+    private final long accessTokenValidityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
+    private static final String BEARER = "Bearer ";
+
+    public JwtUtil(@Value("${jwt.secret}") String secret,
+                   @Value("${jwt.access-token-validity-in-seconds}") long accessTokenValidity,
+                   @Value("${jwt.refresh-token-validity-in-seconds}") long refreshTokenValidity) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenValidityInMilliseconds = accessTokenValidity * 1000;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidity * 1000;
+    }
+
+    public String generateAccessToken(User user) {
+        Date now = new Date();
+        Date expirationTime = new Date(now.getTime() + accessTokenValidityInMilliseconds);
+
+        return Jwts.builder()
+            .setSubject(user.getId().toString())
+            .setId(UUID.randomUUID().toString())
+            .claim("email", user.getEmail())
+            .setIssuedAt(now)
+            .setExpiration(expirationTime)
+            .signWith(secretKey, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public String generateRefreshToken(User user) {
+        Date now = new Date();
+        Date expirationTime = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
+
+        return Jwts.builder()
+            .setSubject(user.getId().toString())
+            .setId(UUID.randomUUID().toString())
+            .setIssuedAt(now)
+            .setExpiration(expirationTime)
+            .signWith(secretKey, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public String extractToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith(BEARER)) {
+            return header.substring(BEARER.length());
+        }
+
+        if (request.getCookies() != null) {
+            return Arrays.stream(request.getCookies())
+                .filter(c -> "accessToken".equals(c.getName()))
+                .findFirst()
+                .map(c -> {
+                    try {
+                        String v = URLDecoder.decode(c.getValue(), StandardCharsets.UTF_8);
+                        if (v.startsWith(BEARER)) {
+                            return v.substring(BEARER.length());
+                        }
+                        return v;
+                    } catch (Exception ex) {
+                        return null;
+                    }
+                })
+                .orElse(null);
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Claims getClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        } catch (ExpiredJwtException ex) {
+            throw new RuntimeException("토큰이 만료되었습니다.", ex);
+        } catch (JwtException | IllegalArgumentException ex) {
+            throw new RuntimeException("유효하지 않은 토큰입니다.", ex);
+        }
+    }
+
+    public String getEmail(String token) {
+        return getClaims(token).getSubject();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
     properties:
       hibernate.format_sql: true
       hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
-  jwt:
-    secret: '${JWT_SECRET}'
-    access-token-validity-in-seconds: 3600
-    refresh-token-validity-in-seconds: 604800
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity-in-seconds: 3600
+  refresh-token-validity-in-seconds: 604800

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,7 @@ spring:
     properties:
       hibernate.format_sql: true
       hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
+  jwt:
+    secret: '${JWT_SECRET}'
+    access-token-validity-in-seconds: 3600
+    refresh-token-validity-in-seconds: 604800

--- a/src/test/java/com/shootdoori/mercenary/MercenaryRecruitmentTest.java
+++ b/src/test/java/com/shootdoori/mercenary/MercenaryRecruitmentTest.java
@@ -209,7 +209,7 @@ class MercenaryRecruitmentTest {
                 "두리FC",
                 User.create(
                     "김학생", "아마추어", "student@example.com", "student@kangwon.ac.kr",
-                    "010-1234-5678", "공격수", "강원대학교", "컴퓨터공학과", "20", "안녕하세요!"),
+                    "asdf02~!", "010-1234-5678", "공격수", "강원대학교", "컴퓨터공학과", "20", "안녕하세요!"),
                 "강원대학교", TeamType.CENTRAL_CLUB, SkillLevel.AMATEUR, "즐겜해요~"
             );
         }

--- a/src/test/java/com/shootdoori/profile/ProfileTest.java
+++ b/src/test/java/com/shootdoori/profile/ProfileTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 public class ProfileTest {
@@ -35,6 +36,9 @@ public class ProfileTest {
 
     @Mock
     private ProfileMapper profileMapper;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @InjectMocks
     private ProfileService profileService;
@@ -47,13 +51,13 @@ public class ProfileTest {
     void setup() {
         createRequest = new ProfileCreateRequest(
             "jam", "아마추어", "test@email.com", "test@ac.kr",
-            "010-0000-0000", "공격수", "knu", "cs",
+            "asdf02~!", "010-0000-0000", "공격수", "knu", "cs",
             "20", "hello, world"
         );
 
         user = User.create(
             createRequest.name(), createRequest.skillLevel(), createRequest.email(), createRequest.universityEmail(),
-            createRequest.phoneNumber(), createRequest.position(), createRequest.university(),
+            createRequest.password(), createRequest.phoneNumber(), createRequest.position(), createRequest.university(),
             createRequest.department(), createRequest.studentYear(), createRequest.bio()
         );
     }
@@ -81,6 +85,9 @@ public class ProfileTest {
         // given
         when(profileRepository.existsByEmailOrUniversityEmail(createRequest.email(), createRequest.universityEmail()))
             .thenReturn(false);
+
+        when(passwordEncoder.encode(any(String.class))).thenReturn("encodedPassword");
+
         when(profileRepository.save(any(User.class))).thenReturn(user);
 
         when(profileMapper.toProfileResponse(user)).thenReturn(
@@ -105,7 +112,7 @@ public class ProfileTest {
         // given
         ProfileCreateRequest invalidRequest = new ProfileCreateRequest(
             "jam", "아마추어", "new@email.com", "new@ac.kr",
-            "010-1111-1111", "마법사", "knu", "cs",
+            "asdf02~!", "010-1111-1111", "마법사", "knu", "cs",
             "20", "hello, world"
         );
 
@@ -119,7 +126,7 @@ public class ProfileTest {
         // given
         ProfileCreateRequest duplicateRequest = new ProfileCreateRequest(
             "jam", "아마추어", "duplicate@email.com", "test@kangwon.ac.kr",
-            "010-0000-0000", "공격수", "knu", "cs",
+            "asdf02~!","010-0000-0000", "공격수", "knu", "cs",
             "20", "hello, world"
         );
 


### PR DESCRIPTION
# 🔥 Pull Request
---

## 🛠️ 뭘 했는지
### 사용자 인증 기능 추가

- User entity 수정
  - User 엔티티에 암호화된 password를 저장하도록 필드를 추가하고, PasswordEncoder를 이용해 회원가입 시 비밀번호를 암호화

- 회원가입/로그인 API 구현
  - `AuthService`와 `LoginController`를 추가하여 이메일과 비밀번호 기반의 회원가입 및 로그인 기능 구현

### JWT 토큰 기반 인증 시스템 구축
- JWT 발급 및 검증
  - jjwt 라이브러리를 사용
  - 로그인 성공 시 사용자 정보를 담은 JWT 액세스 토큰을 발급하고, 요청 시 토큰의 유효성을 검증하는 JwtUtil을 구현했습니다.

- Spring Security 설정
  - 로그인/회원가입(/api/auth/**) 경로는 인증 없이 접근을 허용하고, 그 외 대부분의 API는 인증된 사용자만 접근할 수 있도록 설정
  - JWT 사용 세션 관리 정책: STATELESS

### 그 외
- `@LoginUser` Argument Resolver
  - 컨트롤러에서 JWT 토큰을 통해 인증된 사용자 정보를 파라미터로 편리하게 주입받을 수 있는 `@LoginUser` 어노테이션과 ArgumentResolver 구현

- 환경 변수 관리
  - application.yml의 JWT 시크릿 키 등 민감한 정보를 환경 변수로 분리 (`MatchAppliaction`의 구성 편집)
  <img width="448" height="416" alt="image" src="https://github.com/user-attachments/assets/72032bbf-c236-4451-84b9-7b9243d4a90d" />
    - `JWT_SECRET`은 `util` 폴더의 `JwtSecretGenerator`를 통해 생성

- 변경된 로직에 맞춰 코드 수정
  - java 코드: `TeamController`
  - test 코드: ProfileTest`, `MercenaryRecruitmentTest`
---

## ✅ 확인 사항
- [X] 로컬에서 잘 돌아감
- [X] 기존 기능 안 망가뜨림
- [X] 코드 정리함
- [X] postman 테스트 완료
---

## 👀 특히 봐주세요!
- 비밀번호 암호화 부분, 로그인 시 비밀번호 검증 함수 이름 (samePassword)이 괜찮은지 봐주세요
- `JwtUtil.java` 에서 추가로 필요한 정보가 있는지 봐주세요

- 현재 accessToken만 반환하는데 refreshToken도 추가하려고 하는데 이대로 진행해도 괜찮을까요?
- Role로 ADMIN, USER를 구분하는 코드는 작성하지 않았습니다
---

*PR 확인 부탁드려요! 🙏*