### PR TITLE
Fix 가입 요청 승인 실패 해결 & 대기 중 상태의 신청만 처리할 수 있는 예외를 Bad Request로 변경

### DIFF
--- a/src/main/java/com/shootdoori/match/dto/JoinWaitingMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinWaitingMapper.java
@@ -12,7 +12,7 @@ public class JoinWaitingMapper {
             joinWaiting.getApplicant().getId(),
             joinWaiting.getStatus().getDisplayName(),
             joinWaiting.getDecisionReason(),
-            joinWaiting.getDecidedBy() != null ? joinWaiting.getDecidedBy().toString() : null,
+            joinWaiting.getDecidedBy() != null ? joinWaiting.getDecidedBy().getName() : null,
             joinWaiting.getDecidedAt()
         );
     }

--- a/src/main/java/com/shootdoori/match/entity/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/Team.java
@@ -180,15 +180,16 @@ public class Team extends DateEntity {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) {
+        if (this == o) return true;
+        if (o == null || !(o instanceof Team)) {
             return false;
         }
         Team team = (Team) o;
-        return Objects.equals(teamId, team.teamId);
+        return Objects.equals(getTeamId(), team.getTeamId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(teamId);
+        return Objects.hashCode(getTeamId());
     }
 }

--- a/src/main/java/com/shootdoori/match/exception/ErrorCode.java
+++ b/src/main/java/com/shootdoori/match/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     LAST_TEAM_MEMBER_REMOVAL_NOT_ALLOWED("마지막 멤버는 제거할 수 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_MEMBER_COUNT("멤버 수가 유효 범위를 벗어났습니다. (0~100명)", HttpStatus.BAD_REQUEST),
 
-    JOIN_WAITING_NOT_PENDING("대기중 상태의 신청만 처리할 수 있습니다.", HttpStatus.CONFLICT),
+    JOIN_WAITING_NOT_PENDING("대기중 상태의 신청만 처리할 수 있습니다.", HttpStatus.BAD_REQUEST),
     JOIN_WAITING_INVALID_TRANSITION("현재 상태에서 요청된 상태로 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
     JOIN_WAITING_ALREADY_PENDING("이미 대기중인 신청이 존재합니다.", HttpStatus.CONFLICT),
     JOIN_WAITING_NOT_FOUND("해당 가입 신청을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지
- 가입 요청 승인 실패 해결
  - Team 엔티티 equals() 메서드에서 getClass() 대신 instanceof 사용하여 프록시 객체 처리
  - 필드 직접 접근 대신 getTeamId() 메서드 사용하여 프록시에서도 올바른 ID 값 반환
  - JoinWaitingMapper에서 decidedBy 필드를 User.toString() 대신 User.getName()으로 변경

- 대기 중 상태의 신청만 처리할 수 있는 예외를 Bad Request로 변경

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
❌ 

---

*PR 확인 부탁드려요! 🙏*