### PR TITLE
feat: 비밀번호 재설정 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	runtimeOnly 'com.h2database:h2'
 //	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/shootdoori/match/controller/PasswordResetController.java
+++ b/src/main/java/com/shootdoori/match/controller/PasswordResetController.java
@@ -1,0 +1,38 @@
+package com.shootdoori.match.controller;
+
+import com.shootdoori.match.dto.*;
+import com.shootdoori.match.service.PasswordResetService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/password-reset")
+public class PasswordResetController {
+
+    private final PasswordResetService passwordResetService;
+
+    public PasswordResetController(PasswordResetService passwordResetService) {
+        this.passwordResetService = passwordResetService;
+    }
+
+    @PostMapping("/send-code")
+    public ResponseEntity<MessageResponse> sendVerificationCode(@RequestBody SendCodeRequest request) {
+        passwordResetService.sendVerificationCode(request.email());
+        return ResponseEntity.ok(new MessageResponse("인증번호가 이메일로 발송되었습니다."));
+    }
+
+    @PostMapping("/verify-code")
+    public ResponseEntity<PasswordTokenResponse> verifyCode(@RequestBody VerifyCodeRequest request) {
+        String token = passwordResetService.verifyCodeAndIssueToken(request.email(), request.code());
+        return ResponseEntity.ok(new PasswordTokenResponse(token));
+    }
+
+    @PostMapping("/confirm")
+    public ResponseEntity<MessageResponse> confirmPasswordReset(@RequestBody ResetPasswordRequest request) {
+        passwordResetService.resetPasswordWithToken(request.token(), request.password());
+        return ResponseEntity.ok(new MessageResponse("비밀번호가 성공적으로 변경되었습니다."));
+    }
+}

--- a/src/main/java/com/shootdoori/match/dto/MessageResponse.java
+++ b/src/main/java/com/shootdoori/match/dto/MessageResponse.java
@@ -1,0 +1,4 @@
+package com.shootdoori.match.dto;
+
+public record MessageResponse(String message) {
+}

--- a/src/main/java/com/shootdoori/match/dto/PasswordTokenResponse.java
+++ b/src/main/java/com/shootdoori/match/dto/PasswordTokenResponse.java
@@ -1,0 +1,4 @@
+package com.shootdoori.match.dto;
+
+public record PasswordTokenResponse(String token) {
+}

--- a/src/main/java/com/shootdoori/match/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/ResetPasswordRequest.java
@@ -1,0 +1,4 @@
+package com.shootdoori.match.dto;
+
+public record ResetPasswordRequest(String token, String password) {
+}

--- a/src/main/java/com/shootdoori/match/dto/SendCodeRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/SendCodeRequest.java
@@ -1,0 +1,4 @@
+package com.shootdoori.match.dto;
+
+public record SendCodeRequest(String email) {
+}

--- a/src/main/java/com/shootdoori/match/dto/VerifyCodeRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/VerifyCodeRequest.java
@@ -1,0 +1,4 @@
+package com.shootdoori.match.dto;
+
+public record VerifyCodeRequest(String email, String code) {
+}

--- a/src/main/java/com/shootdoori/match/entity/BasePasswordToken.java
+++ b/src/main/java/com/shootdoori/match/entity/BasePasswordToken.java
@@ -1,0 +1,42 @@
+package com.shootdoori.match.entity;
+
+import com.shootdoori.match.exception.UnauthorizedException;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+public abstract class BasePasswordToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(nullable = false)
+    protected LocalDateTime expiryDate;
+
+    protected BasePasswordToken() {}
+
+    protected BasePasswordToken(User user, int expiryMinutes) {
+        this.user = user;
+        this.expiryDate = LocalDateTime.now().plusMinutes(expiryMinutes);
+    }
+
+    public User getUser() { return user; }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiryDate);
+    }
+
+    public void validateExpiryDate() {
+        if (isExpired()) {
+            throw new UnauthorizedException("토큰이 만료되었습니다.");
+        }
+    }
+
+    protected void updateExpiryDate(int expiryMinutes) {
+        this.expiryDate = LocalDateTime.now().plusMinutes(expiryMinutes);
+    }
+}

--- a/src/main/java/com/shootdoori/match/entity/PasswordOtpToken.java
+++ b/src/main/java/com/shootdoori/match/entity/PasswordOtpToken.java
@@ -1,0 +1,38 @@
+package com.shootdoori.match.entity;
+
+import com.shootdoori.match.exception.UnauthorizedException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class PasswordOtpToken extends BasePasswordToken {
+
+    @Column(nullable = false)
+    private String code;
+
+    protected PasswordOtpToken() {}
+
+    public PasswordOtpToken(User user, String code, int expiryMinutes) {
+        super(user, expiryMinutes);
+        this.code = code;
+    }
+
+    public boolean matches(String rawCode, PasswordEncoder passwordEncoder) {
+        return passwordEncoder.matches(rawCode, this.code);
+    }
+
+    public void validateCode(String rawCode, PasswordEncoder passwordEncoder) {
+        validateExpiryDate();
+        if (!matches(rawCode, passwordEncoder)) {
+            throw new UnauthorizedException("인증번호가 일치하지 않습니다.");
+        }
+    }
+
+    public void updateCode(String newCode, int expiryMinutes) {
+        this.code = newCode;
+        updateExpiryDate(expiryMinutes);
+    }
+}

--- a/src/main/java/com/shootdoori/match/entity/PasswordResetToken.java
+++ b/src/main/java/com/shootdoori/match/entity/PasswordResetToken.java
@@ -1,0 +1,26 @@
+package com.shootdoori.match.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+
+@Entity
+public class PasswordResetToken extends BasePasswordToken {
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    protected PasswordResetToken() {}
+
+    public PasswordResetToken(User user, String token, int expiryMinutes) {
+        super(user, expiryMinutes);
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void updateToken(String newToken, int expiryMinutes) {
+        this.token = newToken;
+        updateExpiryDate(expiryMinutes);
+    }
+}

--- a/src/main/java/com/shootdoori/match/entity/User.java
+++ b/src/main/java/com/shootdoori/match/entity/User.java
@@ -256,6 +256,10 @@ public class User extends DateEntity {
         this.password.validate(rawPassword, passwordEncoder);
     }
 
+    public void changePassword(String encodedPassword) {
+        this.password = Password.of(encodedPassword);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {

--- a/src/main/java/com/shootdoori/match/repository/PasswordOtpTokenRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/PasswordOtpTokenRepository.java
@@ -1,0 +1,12 @@
+package com.shootdoori.match.repository;
+
+import com.shootdoori.match.entity.PasswordOtpToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PasswordOtpTokenRepository extends JpaRepository<PasswordOtpToken, Long> {
+    Optional<PasswordOtpToken> findByUser_Email(String email);
+
+    Optional<PasswordOtpToken> findByUser_Id(Long userId);
+}

--- a/src/main/java/com/shootdoori/match/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,12 @@
+package com.shootdoori.match.repository;
+
+import com.shootdoori.match.entity.PasswordResetToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+    Optional<PasswordResetToken> findByToken(String token);
+
+    Optional<PasswordResetToken> findByUser_Id(Long userId);
+}

--- a/src/main/java/com/shootdoori/match/service/MailService.java
+++ b/src/main/java/com/shootdoori/match/service/MailService.java
@@ -1,0 +1,27 @@
+package com.shootdoori.match.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MailService {
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromAddress;
+
+    public MailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void sendEmail(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromAddress);
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/shootdoori/match/service/PasswordResetService.java
+++ b/src/main/java/com/shootdoori/match/service/PasswordResetService.java
@@ -1,0 +1,98 @@
+package com.shootdoori.match.service;
+
+import com.shootdoori.match.entity.PasswordOtpToken;
+import com.shootdoori.match.entity.PasswordResetToken;
+import com.shootdoori.match.entity.User;
+import com.shootdoori.match.exception.UnauthorizedException;
+import com.shootdoori.match.repository.PasswordOtpTokenRepository;
+import com.shootdoori.match.repository.PasswordResetTokenRepository;
+import com.shootdoori.match.repository.ProfileRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+@Transactional
+public class PasswordResetService {
+
+    private final ProfileRepository profileRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final MailService mailService;
+    private final PasswordOtpTokenRepository otpTokenRepository;
+    private final PasswordResetTokenRepository resetTokenRepository;
+
+    private static final int OTP_EXPIRATION_MINUTES = 3;
+    private static final int RESET_TOKEN_EXPIRATION_MINUTES = 5;
+
+    public PasswordResetService(ProfileRepository profileRepository, PasswordEncoder passwordEncoder, MailService mailService,
+                                PasswordOtpTokenRepository otpTokenRepository, PasswordResetTokenRepository resetTokenRepository) {
+        this.profileRepository = profileRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.mailService = mailService;
+        this.otpTokenRepository = otpTokenRepository;
+        this.resetTokenRepository = resetTokenRepository;
+    }
+
+    public void sendVerificationCode(String email) {
+        User user = profileRepository.findByEmail(email).orElse(null);
+
+        String rawCode = generateOtpCode();
+        String encodedCode = passwordEncoder.encode(rawCode);
+
+        PasswordOtpToken otpToken = otpTokenRepository.findByUser_Id(user.getId())
+                    .map(existing -> {
+                        existing.updateCode(encodedCode, OTP_EXPIRATION_MINUTES);
+                return existing;
+            })
+            .orElseGet(() -> new PasswordOtpToken(user, encodedCode, OTP_EXPIRATION_MINUTES));
+
+        otpTokenRepository.save(otpToken);
+
+        String subject = "[슛도리] 비밀번호 재설정 인증번호 안내";
+        String text = "인증번호: " + rawCode + "\n3분 안에 입력해주세요.";
+
+        mailService.sendEmail(email, subject, text);
+    }
+
+    public String verifyCodeAndIssueToken(String email, String code) {
+        PasswordOtpToken otpToken = otpTokenRepository.findByUser_Email(email)
+                .orElseThrow(() -> new UnauthorizedException("인증번호를 발급하지 못했습니다."));
+        otpToken.validateCode(code, passwordEncoder);
+
+        User user = otpToken.getUser();
+        String tempResetTokenValue = UUID.randomUUID().toString();
+
+        PasswordResetToken resetToken = resetTokenRepository.findByUser_Id(user.getId())
+            .map(existing -> {
+                existing.updateToken(tempResetTokenValue, RESET_TOKEN_EXPIRATION_MINUTES);
+                return existing;
+            })
+            .orElseGet(() -> new PasswordResetToken(user, tempResetTokenValue, RESET_TOKEN_EXPIRATION_MINUTES));
+
+        resetTokenRepository.save(resetToken);
+        otpTokenRepository.delete(otpToken);
+
+        return tempResetTokenValue;
+    }
+
+    public void resetPasswordWithToken(String token, String newPassword) {
+        PasswordResetToken resetToken = resetTokenRepository.findByToken(token)
+            .orElseThrow(() -> new UnauthorizedException("인증이 필요합니다."));
+        resetToken.validateExpiryDate();
+
+        User user = resetToken.getUser();
+        user.changePassword(passwordEncoder.encode(newPassword));
+        profileRepository.save(user);
+
+        resetTokenRepository.delete(resetToken);
+    }
+
+    private String generateOtpCode() {
+        SecureRandom random = new SecureRandom();
+        return String.format("%06d", random.nextInt(1000000));
+    }
+}

--- a/src/main/java/com/shootdoori/match/service/PasswordResetService.java
+++ b/src/main/java/com/shootdoori/match/service/PasswordResetService.java
@@ -39,6 +39,14 @@ public class PasswordResetService {
 
     public void sendVerificationCode(String email) {
         User user = profileRepository.findByEmail(email).orElse(null);
+        if (user == null) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return;
+        }
 
         String rawCode = generateOtpCode();
         String encodedCode = passwordEncoder.encode(rawCode);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,10 @@ spring.datasource.password=
 jwt.secret=
 jwt.access-token-validity-in-seconds=360000
 jwt.refresh-token-validity-in-seconds=360000
+
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=shootdoori.official@gmail.com
+spring.mail.password=
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/test/java/com/shootdoori/match/service/MailServiceTest.java
+++ b/src/test/java/com/shootdoori/match/service/MailServiceTest.java
@@ -1,0 +1,27 @@
+package com.shootdoori.match.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class MailServiceTest {
+    @Autowired
+    private MailService mailService;
+
+    @Test
+    @DisplayName("이메일_실제_발송_테스트")
+    void send_email_test() {
+        // given
+        String toEmail = "shootdoori.official@gmail.com";
+        String subject = "스프링 부트 이메일 테스트";
+        String code = "SMTP 설정 성공.";
+
+        // when
+        mailService.sendEmail(toEmail, subject, code);
+
+        // then
+        System.out.println("이메일 발송 완료.");
+    }
+}

--- a/src/test/java/com/shootdoori/match/service/PasswordResetServiceTest.java
+++ b/src/test/java/com/shootdoori/match/service/PasswordResetServiceTest.java
@@ -1,0 +1,327 @@
+package com.shootdoori.match.service;
+
+import com.shootdoori.match.entity.PasswordOtpToken;
+import com.shootdoori.match.entity.PasswordResetToken;
+import com.shootdoori.match.entity.User;
+import com.shootdoori.match.exception.UnauthorizedException;
+import com.shootdoori.match.repository.PasswordOtpTokenRepository;
+import com.shootdoori.match.repository.PasswordResetTokenRepository;
+import com.shootdoori.match.repository.ProfileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceTest {
+
+    @Mock private ProfileRepository profileRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private MailService mailService;
+    @Mock private PasswordOtpTokenRepository otpTokenRepository;
+    @Mock private PasswordResetTokenRepository resetTokenRepository;
+
+    @InjectMocks private PasswordResetService passwordResetService;
+
+    private User testUser;
+    private String testEmail;
+
+    @BeforeEach
+    void setUp() {
+        testEmail = "test@example.com";
+        testUser = mock(User.class);
+        lenient().when(testUser.getId()).thenReturn(1L);
+    }
+
+    @Test
+    @DisplayName("인증번호 최초 발송 성공 - 새 토큰 생성")
+    void sendVerificationCode_FirstTime_Success() {
+        // given
+        when(profileRepository.findByEmail(testEmail)).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.encode(anyString())).thenReturn("encodedCode");
+        when(otpTokenRepository.findByUser_Id(testUser.getId())).thenReturn(Optional.empty());
+
+        // when
+        passwordResetService.sendVerificationCode(testEmail);
+
+        // then
+        verify(profileRepository).findByEmail(testEmail);
+        verify(otpTokenRepository).findByUser_Id(testUser.getId());
+        verify(otpTokenRepository).save(any(PasswordOtpToken.class));
+
+        ArgumentCaptor<String> emailCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> textCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(mailService).sendEmail(emailCaptor.capture(), subjectCaptor.capture(), textCaptor.capture());
+
+        assertThat(emailCaptor.getValue()).isEqualTo(testEmail);
+        assertThat(subjectCaptor.getValue()).contains("비밀번호 재설정");
+        assertThat(textCaptor.getValue()).contains("인증번호:");
+    }
+
+    @Test
+    @DisplayName("인증번호 재발송 - 기존 토큰 업데이트")
+    void sendVerificationCode_SecondTime_UpdateExisting() {
+        // given
+        PasswordOtpToken existingToken = mock(PasswordOtpToken.class);
+
+        when(profileRepository.findByEmail(testEmail)).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.encode(anyString())).thenReturn("newEncodedCode");
+        when(otpTokenRepository.findByUser_Id(testUser.getId())).thenReturn(Optional.of(existingToken));
+
+        // when
+        passwordResetService.sendVerificationCode(testEmail);
+
+        // then
+        verify(otpTokenRepository).findByUser_Id(testUser.getId());
+        verify(existingToken).updateCode("newEncodedCode", 3);
+        verify(otpTokenRepository).save(existingToken);
+        verify(mailService).sendEmail(eq(testEmail), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("인증번호 연속 두 번 발송 - 업데이트 두 번 수행")
+    void sendVerificationCode_TwiceInARow_UpdatesTwice() {
+        // given
+        PasswordOtpToken existingToken = mock(PasswordOtpToken.class);
+
+        when(profileRepository.findByEmail(testEmail)).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.encode(anyString())).thenReturn("encodedCode1", "encodedCode2");
+
+        // 첫 번째 호출: 새 토큰 생성
+        when(otpTokenRepository.findByUser_Id(testUser.getId())).thenReturn(Optional.empty());
+
+        // 첫 번째 발송
+        passwordResetService.sendVerificationCode(testEmail);
+
+        // 두 번째 호출: 기존 토큰 업데이트
+        when(otpTokenRepository.findByUser_Id(testUser.getId())).thenReturn(Optional.of(existingToken));
+
+        // when - 두 번째 발송
+        passwordResetService.sendVerificationCode(testEmail);
+
+        // then
+        verify(otpTokenRepository, times(2)).findByUser_Id(testUser.getId());
+        verify(otpTokenRepository, times(2)).save(any(PasswordOtpToken.class));
+        verify(existingToken).updateCode("encodedCode2", 3);
+        verify(mailService, times(2)).sendEmail(eq(testEmail), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 인증번호 발송 시 예외 발생")
+    void sendVerificationCode_UserNotFound() {
+        // given
+        when(profileRepository.findByEmail(testEmail)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> passwordResetService.sendVerificationCode(testEmail))
+            .isInstanceOf(NullPointerException.class);
+
+        verify(otpTokenRepository, never()).save(any());
+        verify(mailService, never()).sendEmail(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("인증번호 검증 및 토큰 최초 발급 성공")
+    void verifyCodeAndIssueToken_FirstTime_Success() {
+        // given
+        String code = "123456";
+        PasswordOtpToken otpToken = mock(PasswordOtpToken.class);
+
+        when(otpTokenRepository.findByUser_Email(testEmail)).thenReturn(Optional.of(otpToken));
+        when(otpToken.getUser()).thenReturn(testUser);
+        when(resetTokenRepository.findByUser_Id(testUser.getId())).thenReturn(Optional.empty());
+        doNothing().when(otpToken).validateCode(code, passwordEncoder);
+
+        // when
+        String token = passwordResetService.verifyCodeAndIssueToken(testEmail, code);
+
+        // then
+        assertThat(token).isNotNull();
+        assertThat(token).isNotEmpty();
+
+        verify(otpToken).validateCode(code, passwordEncoder);
+        verify(resetTokenRepository).findByUser_Id(testUser.getId());
+        verify(resetTokenRepository).save(any(PasswordResetToken.class));
+        verify(otpTokenRepository).delete(otpToken);
+    }
+
+    @Test
+    @DisplayName("인증번호 재검증 - 기존 리셋 토큰 업데이트")
+    void verifyCodeAndIssueToken_SecondTime_UpdateExisting() {
+        // given
+        String code = "123456";
+        PasswordOtpToken otpToken = mock(PasswordOtpToken.class);
+        PasswordResetToken existingResetToken = mock(PasswordResetToken.class);
+
+        when(otpTokenRepository.findByUser_Email(testEmail)).thenReturn(Optional.of(otpToken));
+        when(otpToken.getUser()).thenReturn(testUser);
+        when(resetTokenRepository.findByUser_Id(testUser.getId())).thenReturn(Optional.of(existingResetToken));
+        doNothing().when(otpToken).validateCode(code, passwordEncoder);
+
+        // when
+        String token = passwordResetService.verifyCodeAndIssueToken(testEmail, code);
+
+        // then
+        assertThat(token).isNotNull();
+        assertThat(token).isNotEmpty();
+
+        verify(otpToken).validateCode(code, passwordEncoder);
+        verify(resetTokenRepository).findByUser_Id(testUser.getId());
+        verify(existingResetToken).updateToken(anyString(), eq(5));
+        verify(resetTokenRepository).save(existingResetToken);
+        verify(otpTokenRepository).delete(otpToken);
+    }
+
+    @Test
+    @DisplayName("인증번호 연속 두 번 검증 - 리셋 토큰 업데이트 두 번 수행")
+    void verifyCodeAndIssueToken_TwiceInARow_UpdatesTwice() {
+        // given
+        String code = "123456";
+        PasswordOtpToken otpToken1 = mock(PasswordOtpToken.class);
+        PasswordOtpToken otpToken2 = mock(PasswordOtpToken.class);
+        PasswordResetToken existingResetToken = mock(PasswordResetToken.class);
+
+        when(otpToken1.getUser()).thenReturn(testUser);
+        when(otpToken2.getUser()).thenReturn(testUser);
+
+        // 첫 번째와 두 번째 검증 설정
+        when(otpTokenRepository.findByUser_Email(testEmail))
+            .thenReturn(Optional.of(otpToken1))
+            .thenReturn(Optional.of(otpToken2));
+
+        when(resetTokenRepository.findByUser_Id(testUser.getId()))
+            .thenReturn(Optional.empty())
+            .thenReturn(Optional.of(existingResetToken));
+
+        doNothing().when(otpToken1).validateCode(code, passwordEncoder);
+        doNothing().when(otpToken2).validateCode(code, passwordEncoder);
+
+        // when
+        String firstToken = passwordResetService.verifyCodeAndIssueToken(testEmail, code);
+        String secondToken = passwordResetService.verifyCodeAndIssueToken(testEmail, code);
+
+        // then
+        assertThat(firstToken).isNotNull();
+        assertThat(secondToken).isNotNull();
+        assertThat(firstToken).isNotEqualTo(secondToken);
+
+        verify(resetTokenRepository, times(2)).findByUser_Id(testUser.getId());
+        verify(resetTokenRepository, times(2)).save(any(PasswordResetToken.class));
+        verify(existingResetToken).updateToken(anyString(), eq(5));
+        verify(otpTokenRepository, times(2)).delete(any(PasswordOtpToken.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 OTP 토큰으로 검증 시 예외 발생")
+    void verifyCodeAndIssueToken_OtpTokenNotFound() {
+        // given
+        String code = "123456";
+        when(otpTokenRepository.findByUser_Email(testEmail)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> passwordResetService.verifyCodeAndIssueToken(testEmail, code))
+            .isInstanceOf(UnauthorizedException.class);
+
+        verify(resetTokenRepository, never()).save(any());
+        verify(otpTokenRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("잘못된 인증번호로 검증 시 예외 발생")
+    void verifyCodeAndIssueToken_InvalidCode() {
+        // given
+        String code = "wrong";
+        PasswordOtpToken otpToken = mock(PasswordOtpToken.class);
+
+        when(otpTokenRepository.findByUser_Email(testEmail)).thenReturn(Optional.of(otpToken));
+        doThrow(new UnauthorizedException("인증번호가 일치하지 않습니다."))
+            .when(otpToken).validateCode(code, passwordEncoder);
+
+        // when & then
+        assertThatThrownBy(() -> passwordResetService.verifyCodeAndIssueToken(testEmail, code))
+            .isInstanceOf(UnauthorizedException.class);
+
+        verify(resetTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("토큰으로 비밀번호 재설정 성공")
+    void resetPasswordWithToken_Success() {
+        // given
+        String token = "valid-token";
+        String newPassword = "newPassword123!";
+        String encodedPassword = "encodedNewPassword";
+
+        PasswordResetToken resetToken = mock(PasswordResetToken.class);
+
+        when(resetTokenRepository.findByToken(token)).thenReturn(Optional.of(resetToken));
+        when(resetToken.getUser()).thenReturn(testUser);
+        when(passwordEncoder.encode(newPassword)).thenReturn(encodedPassword);
+        doNothing().when(resetToken).validateExpiryDate();
+        doNothing().when(testUser).changePassword(encodedPassword);
+
+        // when
+        passwordResetService.resetPasswordWithToken(token, newPassword);
+
+        // then
+        verify(resetToken).validateExpiryDate();
+        verify(testUser).changePassword(encodedPassword);
+        verify(profileRepository).save(testUser);
+        verify(resetTokenRepository).delete(resetToken);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 비밀번호 재설정 시 예외 발생")
+    void resetPasswordWithToken_InvalidToken() {
+        // given
+        String token = "invalid-token";
+        String newPassword = "newPassword123!";
+
+        when(resetTokenRepository.findByToken(token)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> passwordResetService.resetPasswordWithToken(token, newPassword))
+            .isInstanceOf(UnauthorizedException.class);
+
+        verify(profileRepository, never()).save(any());
+        verify(resetTokenRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("만료된 토큰으로 비밀번호 재설정 시 예외 발생")
+    void resetPasswordWithToken_ExpiredToken() {
+        // given
+        String token = "expired-token";
+        String newPassword = "newPassword123!";
+
+        PasswordResetToken resetToken = mock(PasswordResetToken.class);
+
+        when(resetTokenRepository.findByToken(token)).thenReturn(Optional.of(resetToken));
+        doThrow(new UnauthorizedException("토큰이 만료되었습니다."))
+            .when(resetToken).validateExpiryDate();
+
+        // when & then
+        assertThatThrownBy(() -> passwordResetService.resetPasswordWithToken(token, newPassword))
+            .isInstanceOf(UnauthorizedException.class);
+
+        verify(profileRepository, never()).save(any());
+        verify(resetTokenRepository, never()).delete(any());
+    }
+}


### PR DESCRIPTION
# 🔥 Pull Request
---

## 🛠️ 뭘 했는지
- 사용자가 비밀번호를 잊었을 때 이메일 인증을 통해 재설정할 수 있는 기능 구현

### 주요 기능

1. 이메일 인증번호 발송 (POST /api/password-reset/send-code)
- 6자리 OTP 생성 및 이메일 발송
- 3분 유효기간 설정


2. 인증번호 검증 및 토큰 발급 (POST /api/password-reset/verify-code)

- 인증번호(6자리 OTP) 검증 후 임시 리셋 토큰 발급
- 5분 유효기간 설정


3. 비밀번호 재설정 (POST /api/password-reset/confirm)

- 임시 토큰으로 비밀번호 변경
- 변경 완료 후 토큰 삭제

### 구현

- 토큰 관리: 기존 토큰 업데이트 방식 (unique constraint 충돌 방지)
- 보안: BCrypt를 이용한 OTP 암호화, UUID 기반 리셋 토큰 생성

### ✅ 테스트 (11개)

- [x] 인증번호 최초 발송
- [x] 인증번호 재발송
- [x] 인증번호 연속 발송
- [x] 존재하지 않는 이메일 예외 처리
- [x] 토큰 최초 발급
- [x] 토큰  재발급
- [x] 토큰 연속 발급
- [x] 존재하지 않는 OTP 토큰 예외 처리
- [x] 잘못된 인증번호 예외 처리
- [x] 비밀번호 재설정 성공
- [x] 유효하지 않은 토큰 예외 처리
- [x] 만료된 토큰 예외 처리

### 추가 변경 사항
- `User` 엔티티에 비밀번호 변경 함수 추가
---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] postman 테스트 완료
---

## 👀 특히 봐주세요!

1. 토큰 업데이트 로직: 기존 토큰을 찾아서 업데이트하는 방식으로 구현했습니다. 한 사람당 OTP, ResetToken이 하나씩 있을 텐데 비밀번호를 변경하는 것까지 완료하면 둘 다 삭제되겠지만 그렇지 않은 경우 남아있습니다. update되는 방식이라 돌아가는 데에 문제는 없지만 `스케줄러`와 같은 기능을 통해 자동으로 정리해주는 것도 필요할지 모르겠습니다.

2. 이메일로 인증번호 발송 시 이메일이 틀려도 제대로 발송됐다고 하는 걸로 했습니다. 하지만, 보안을 강화하는 것보다 사용자의 편의를 위해 존재하지 않는 이메일인지 알려주는 게 나을까요? 아니면 그대로가 좋을까요?
---

// TODO: 인증 시도 횟수 제한 기능 추가
*PR 확인 부탁드려요! 🙏*