### PR TITLE
fix(password-reset): 존재하지 않는 이메일로 인증코드 발송 테스트 수정

### DIFF
--- a/src/test/java/com/shootdoori/match/service/PasswordResetServiceTest.java
+++ b/src/test/java/com/shootdoori/match/service/PasswordResetServiceTest.java
@@ -21,11 +21,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
-
-import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class PasswordResetServiceTest {
@@ -130,8 +129,8 @@ class PasswordResetServiceTest {
         when(profileRepository.findByEmail(testEmail)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> passwordResetService.sendVerificationCode(testEmail))
-            .isInstanceOf(NullPointerException.class);
+        assertThatCode(() -> passwordResetService.sendVerificationCode(testEmail))
+            .doesNotThrowAnyException();
 
         verify(otpTokenRepository, never()).save(any());
         verify(mailService, never()).sendEmail(anyString(), anyString(), anyString());


### PR DESCRIPTION
# 🔥 Pull Request


## 🛠️ 뭘 했는지

`존재하지 않는 이메일로 인증번호 발송에 대한 테스트`에 대한 오류를 수정했습니다.

<발생 이유>
- 처음에 NPE로 잡고 테스트 하다가 서비스 코드 완성 및 수정하면서 테스트 코드를 바꾸지 않았습니다.

---

## ✅ 확인 사항
- [ ] 로컬에서 잘 돌아감
- [ ] 기존 기능 안 망가뜨림
- [ ] 코드 정리함

---

## 👀 특히 봐주세요!
<!-- 확인해줬으면 하는 부분이나 고민거리 -->
> ex) 이 함수 이름 이상하지 않나요? 더 좋은 이름 있으면 말해주세요!

---

*PR 확인 부탁드려요! 🙏*