### PR TITLE
feat: 대학 이메일 인증 API 구현

### DIFF
--- a/src/main/java/com/shootdoori/match/controller/EmailVerificationController.java
+++ b/src/main/java/com/shootdoori/match/controller/EmailVerificationController.java
@@ -1,0 +1,33 @@
+package com.shootdoori.match.controller;
+
+import com.shootdoori.match.dto.MessageResponse;
+import com.shootdoori.match.dto.SendCodeRequest;
+import com.shootdoori.match.dto.VerifyCodeRequest;
+import com.shootdoori.match.service.EmailVerificationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth/signup/email")
+public class EmailVerificationController {
+    private final EmailVerificationService emailVerificationService;
+
+    public EmailVerificationController(EmailVerificationService emailVerificationService) {
+        this.emailVerificationService = emailVerificationService;
+    }
+
+    @PostMapping("/send-code")
+    public ResponseEntity<MessageResponse> sendCode(@RequestBody SendCodeRequest request) {
+        emailVerificationService.sendVerificationCode(request.email());
+        return ResponseEntity.ok(new MessageResponse("인증번호가 이메일로 발송되었습니다."));
+    }
+
+    @PostMapping("/verify-code")
+    public ResponseEntity<MessageResponse> verifyCode(@RequestBody VerifyCodeRequest request) {
+        emailVerificationService.verifyCode(request.email(), request.code());
+        return ResponseEntity.ok(new MessageResponse("이메일 인증이 완료되었습니다."));
+    }
+}

--- a/src/main/java/com/shootdoori/match/controller/EmailVerificationController.java
+++ b/src/main/java/com/shootdoori/match/controller/EmailVerificationController.java
@@ -4,6 +4,7 @@ import com.shootdoori.match.dto.MessageResponse;
 import com.shootdoori.match.dto.SendCodeRequest;
 import com.shootdoori.match.dto.VerifyCodeRequest;
 import com.shootdoori.match.service.EmailVerificationService;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,13 +21,13 @@ public class EmailVerificationController {
     }
 
     @PostMapping("/send-code")
-    public ResponseEntity<MessageResponse> sendCode(@RequestBody SendCodeRequest request) {
+    public ResponseEntity<MessageResponse> sendCode(@Valid @RequestBody SendCodeRequest request) {
         emailVerificationService.sendVerificationCode(request.email());
         return ResponseEntity.ok(new MessageResponse("인증번호가 이메일로 발송되었습니다."));
     }
 
     @PostMapping("/verify-code")
-    public ResponseEntity<MessageResponse> verifyCode(@RequestBody VerifyCodeRequest request) {
+    public ResponseEntity<MessageResponse> verifyCode(@Valid @RequestBody VerifyCodeRequest request) {
         emailVerificationService.verifyCode(request.email(), request.code());
         return ResponseEntity.ok(new MessageResponse("이메일 인증이 완료되었습니다."));
     }

--- a/src/main/java/com/shootdoori/match/dto/SendCodeRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/SendCodeRequest.java
@@ -1,4 +1,14 @@
 package com.shootdoori.match.dto;
 
-public record SendCodeRequest(String email) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SendCodeRequest(
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Pattern(
+        regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.ac\\.kr$",
+        message = "대학교 이메일 형식만 가능합니다. (.ac.kr)"
+    )
+    String email
+) {
 }

--- a/src/main/java/com/shootdoori/match/dto/VerifyCodeRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/VerifyCodeRequest.java
@@ -1,4 +1,18 @@
 package com.shootdoori.match.dto;
 
-public record VerifyCodeRequest(String email, String code) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record VerifyCodeRequest(
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Pattern(
+        regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.ac\\.kr$",
+        message = "대학교 이메일 형식만 가능합니다. (.ac.kr)"
+    )
+    String email,
+
+    @NotBlank(message = "인증번호는 필수 입력값입니다.")
+    String code
+) {
+
 }

--- a/src/main/java/com/shootdoori/match/entity/EmailVerificationCode.java
+++ b/src/main/java/com/shootdoori/match/entity/EmailVerificationCode.java
@@ -1,0 +1,48 @@
+package com.shootdoori.match.entity;
+
+import com.shootdoori.match.exception.ErrorCode;
+import com.shootdoori.match.exception.UnauthorizedException;
+import jakarta.persistence.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Entity
+public class EmailVerificationCode {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String code;
+
+    protected EmailVerificationCode() {}
+
+    public EmailVerificationCode(String email, String code) {
+        this.email = email;
+        this.code = code;
+    }
+
+    public String getEmail() {
+        return this.email;
+    }
+
+    public String getCode() {
+        return this.code;
+    }
+
+    public void updateCode(String newCode) {
+        this.code = newCode;
+    }
+
+    public boolean matches(String rawCode, PasswordEncoder passwordEncoder) {
+        return passwordEncoder.matches(rawCode, this.code);
+    }
+
+    public void validateCode(String rawCode, PasswordEncoder passwordEncoder) {
+        if (!matches(rawCode, passwordEncoder)) {
+            throw new UnauthorizedException(ErrorCode.INVALID_OTP);
+        }
+    }
+}

--- a/src/main/java/com/shootdoori/match/repository/EmailVerificationCodeRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/EmailVerificationCodeRepository.java
@@ -1,0 +1,10 @@
+package com.shootdoori.match.repository;
+
+import com.shootdoori.match.entity.EmailVerificationCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationCodeRepository extends JpaRepository<EmailVerificationCode, Long> {
+    Optional<EmailVerificationCode> findByEmail(String email);
+}

--- a/src/main/java/com/shootdoori/match/service/EmailVerificationService.java
+++ b/src/main/java/com/shootdoori/match/service/EmailVerificationService.java
@@ -1,0 +1,61 @@
+package com.shootdoori.match.service;
+
+import com.shootdoori.match.entity.EmailVerificationCode;
+import com.shootdoori.match.exception.ErrorCode;
+import com.shootdoori.match.exception.UnauthorizedException;
+import com.shootdoori.match.repository.EmailVerificationCodeRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+
+@Service
+@Transactional
+public class EmailVerificationService {
+
+    private final EmailVerificationCodeRepository codeRepository;
+    private final MailService mailService;
+    private final PasswordEncoder passwordEncoder;
+
+    public EmailVerificationService(EmailVerificationCodeRepository codeRepository,
+                                    MailService mailService,
+                                    PasswordEncoder passwordEncoder) {
+        this.codeRepository = codeRepository;
+        this.mailService = mailService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public void sendVerificationCode(String email) {
+        String rawCode = generateOtpCode();
+        String encodedCode = passwordEncoder.encode(rawCode);
+
+        EmailVerificationCode codeEntity = codeRepository.findByEmail(email)
+            .map(existing -> {
+                existing.updateCode(encodedCode);
+                return existing;
+            })
+            .orElseGet(() -> new EmailVerificationCode(email, encodedCode));
+
+        codeRepository.save(codeEntity);
+
+        String subject = "[슛도리] 이메일 인증번호 안내";
+        String text = "인증번호: " + rawCode + "\n회원가입 화면에서 입력해주세요.";
+
+        mailService.sendEmail(email, subject, text);
+    }
+
+    public void verifyCode(String email, String code) {
+        EmailVerificationCode codeEntity = codeRepository.findByEmail(email)
+            .orElseThrow(() -> new UnauthorizedException(ErrorCode.OTP_NOT_FOUND));
+
+        codeEntity.validateCode(code, passwordEncoder);
+
+        codeRepository.delete(codeEntity);
+    }
+
+    private String generateOtpCode() {
+        SecureRandom random = new SecureRandom();
+        return String.format("%06d", random.nextInt(1000000));
+    }
+}

--- a/src/test/java/com/shootdoori/match/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/shootdoori/match/service/EmailVerificationServiceTest.java
@@ -1,0 +1,144 @@
+package com.shootdoori.match.service;
+
+import com.shootdoori.match.entity.EmailVerificationCode;
+import com.shootdoori.match.exception.ErrorCode;
+import com.shootdoori.match.exception.UnauthorizedException;
+import com.shootdoori.match.repository.EmailVerificationCodeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class EmailVerificationServiceTest {
+    @Mock private EmailVerificationCodeRepository codeRepository;
+    @Mock private MailService mailService;
+    @Mock private PasswordEncoder passwordEncoder;
+
+    @InjectMocks private EmailVerificationService emailVerificationService;
+
+    @Test
+    @DisplayName("이메일 인증번호 전송 - 신규 이메일")
+    void sendVerificationCode_newEmail() {
+        // given
+        String email = "new@univ.ac.kr";
+        String encodedCode = "encoded-code";
+
+        // `passwordEncoder.encode`가 어떤 문자열이든 받으면 `encodedCode`를 반환하도록 설정
+        when(passwordEncoder.encode(anyString())).thenReturn(encodedCode);
+        when(codeRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        // when
+        emailVerificationService.sendVerificationCode(email);
+
+        // then
+        // ArgumentCaptor를 사용하여 codeRepository.save()에 전달된 EmailVerificationCode 객체를 캡처
+        ArgumentCaptor<EmailVerificationCode> codeEntityCaptor = ArgumentCaptor.forClass(EmailVerificationCode.class);
+        verify(codeRepository).save(codeEntityCaptor.capture());
+
+        // 캡처된 객체의 인코딩된 코드가 우리가 예상한 값과 일치하는지 확인
+        EmailVerificationCode savedEntity = codeEntityCaptor.getValue();
+        assertThat(savedEntity.getEmail()).isEqualTo(email);
+        assertThat(savedEntity.getCode()).isEqualTo(encodedCode);
+
+        // ArgumentCaptor를 사용하여 mailService.sendEmail()에 전달된 'text' 인자를 캡처
+        ArgumentCaptor<String> mailTextCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mailService).sendEmail(eq(email), anyString(), mailTextCaptor.capture());
+
+        // 메일 본문에 '인증번호: '라는 텍스트가 포함되어 있는지 확인 (랜덤 숫자 자체는 검증 불가)
+        assertThat(mailTextCaptor.getValue()).contains("인증번호: ");
+    }
+
+    @Test
+    @DisplayName("이메일 인증번호 전송 - 기존 이메일에 한 번 더 보내기(코드 업데이트)")
+    void sendVerificationCode_existingEmail() {
+        // given
+        String email = "exist@univ.ac.kr";
+        String newEncodedCode = "new-encoded-code";
+        EmailVerificationCode existing = new EmailVerificationCode(email, "old-encoded-code");
+
+        when(codeRepository.findByEmail(email)).thenReturn(Optional.of(existing));
+        when(passwordEncoder.encode(anyString())).thenReturn(newEncodedCode);
+
+        // when
+        emailVerificationService.sendVerificationCode(email);
+
+        // then
+        // save 메서드가 호출되었는지 확인
+        ArgumentCaptor<EmailVerificationCode> codeEntityCaptor = ArgumentCaptor.forClass(EmailVerificationCode.class);
+        verify(codeRepository).save(codeEntityCaptor.capture());
+
+        // 캡처된 엔티티의 코드가 새로운 인코딩된 코드로 업데이트되었는지 확인
+        EmailVerificationCode updatedEntity = codeEntityCaptor.getValue();
+        assertThat(updatedEntity.getCode()).isEqualTo(newEncodedCode);
+
+        // 메일 발송 여부 확인
+        verify(mailService).sendEmail(eq(email), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("인증 성공 - 저장된 코드와 일치")
+    void verifyCode_success() {
+        // given
+        String email = "test@univ.ac.kr";
+        String rawCode = "123456";
+        String encodedCode = "encoded-code";
+
+        EmailVerificationCode savedCode = new EmailVerificationCode(email, encodedCode);
+
+        when(codeRepository.findByEmail(email)).thenReturn(Optional.of(savedCode));
+        when(passwordEncoder.matches(rawCode, encodedCode)).thenReturn(true);
+
+        // when
+        emailVerificationService.verifyCode(email, rawCode);
+
+        // then
+        verify(codeRepository).delete(savedCode);
+    }
+
+    @Test
+    @DisplayName("인증 실패 - 코드 불일치")
+    void verifyCode_invalidCode() {
+        // given
+        String email = "test@univ.ac.kr";
+        String rawCode = "000000";
+        String encodedCode = "encoded";
+
+        EmailVerificationCode savedCode = new EmailVerificationCode(email, encodedCode);
+
+        when(codeRepository.findByEmail(email)).thenReturn(Optional.of(savedCode));
+        when(passwordEncoder.matches(rawCode, encodedCode)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> emailVerificationService.verifyCode(email, rawCode))
+            .isInstanceOf(UnauthorizedException.class)
+            .hasMessageContaining(ErrorCode.INVALID_OTP.getMessage());
+    }
+
+    @Test
+    @DisplayName("인증 실패 - 해당 이메일 없음")
+    void verifyCode_emailNotFound() {
+        // given
+        String email = "notfound@univ.ac.kr";
+
+        when(codeRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> emailVerificationService.verifyCode(email, "123456"))
+            .isInstanceOf(UnauthorizedException.class)
+            .hasMessageContaining(ErrorCode.OTP_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
# 🔥 Pull Request
---

## 🛠️ 뭘 했는지
- `@RequestMapping("/api/auth/signup/email")`
  - POST `/send-code`: 대학교 이메일로 인증코드 보내기
  - POST `/verify-code`: 인증코드 검증하기
 
- 대학생 이메일은 회원가입 시 무조건 인증해야 하므로 인증코드 객체를 update 방식으로 했습니다. 따라서, 이메일 인증이 끝나면 무조건 삭제됩니다. 

- 테스트 코드
  [x] 이메일 인증번호 전송 - 신규 이메일
  [x] 이메일 인증번호 전송 - 기존 이메일에 한 번 더 보내기(코드 업데이트): 인증을 끝내지 않고 인증코드 객체가 만들어진 경우
  [x] 인증 성공 - 저장된 코드와 일치
  [x] 인증 실패 - 코드 불일치
  [x] 인증 실패 - 이메일과 인증코드가 담겨있는 객체를 찾을 수 없음: (request의 값을 다르게 보낼 수 있으니 혹시 몰라서 만들었습니다)
---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 빌드 성공

---

## 👀 특히 봐주세요!
- 회원가입할 때 대학생 이메일 인증하니까 일부러 엔드포인트를 `/api/auth/signup/email`로 뒀습니다. 괜찮은지 말씀해주세요! (컨트롤러는 따로 생성했습니다)
- 
---

*PR 확인 부탁드려요! 🙏*