### PR TITLE
refactor(join-waiting): JoinWaitingResponseDto에 applicantName 추가 및 decidedBy를 이름으로 일원화

### DIFF
--- a/src/main/java/com/shootdoori/match/dto/JoinWaitingMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinWaitingMapper.java
@@ -8,6 +8,7 @@ public class JoinWaitingMapper {
     public JoinWaitingResponseDto toJoinWaitingResponseDto(JoinWaiting joinWaiting) {
         return new JoinWaitingResponseDto(
             joinWaiting.getId(),
+            joinWaiting.getApplicant().getName(),
             joinWaiting.getTeam().getTeamId(),
             joinWaiting.getApplicant().getId(),
             joinWaiting.getStatus().getDisplayName(),

--- a/src/main/java/com/shootdoori/match/dto/JoinWaitingResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinWaitingResponseDto.java
@@ -2,7 +2,7 @@ package com.shootdoori.match.dto;
 
 import java.time.LocalDateTime;
 
-public record JoinWaitingResponseDto(Long id, Long teamId, Long applicantId, String status,
+public record JoinWaitingResponseDto(Long id, String applicantName, Long teamId, Long applicantId, String status,
                                    String decisionReason, String decidedBy,
                                    LocalDateTime decidedAt) {
 

--- a/src/test/java/com/shootdoori/joinWaiting/JoinWaitingServiceTest.java
+++ b/src/test/java/com/shootdoori/joinWaiting/JoinWaitingServiceTest.java
@@ -164,7 +164,7 @@ public class JoinWaitingServiceTest {
             JoinWaiting joinWaiting = JoinWaiting.create(team, applicant, "파트라슈처럼 뛰겠습니다.");
 
             JoinWaitingResponseDto expected = new JoinWaitingResponseDto(
-                JOIN_WAITING_ID, TEAM_ID, applicantId,
+                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, applicantId,
                 JoinWaitingStatus.PENDING.getDisplayName(),
                 null, null, null
             );
@@ -281,9 +281,9 @@ public class JoinWaitingServiceTest {
                 .thenReturn(false);
 
             JoinWaitingResponseDto expected = new JoinWaitingResponseDto(
-                JOIN_WAITING_ID, TEAM_ID, applicantId,
+                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, applicantId,
                 JoinWaitingStatus.APPROVED.getDisplayName(),
-                "승인합니다", teamLeader.toString(), FIXED_TIME
+                "승인합니다", teamLeader.getName(), FIXED_TIME
             );
 
             when(joinWaitingMapper.toJoinWaitingResponseDto(any(JoinWaiting.class))).thenReturn(
@@ -375,9 +375,9 @@ public class JoinWaitingServiceTest {
                 .thenReturn(Optional.of(joinWaiting));
 
             JoinWaitingResponseDto expected = new JoinWaitingResponseDto(
-                JOIN_WAITING_ID, TEAM_ID, applicantId,
+                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, applicantId,
                 JoinWaitingStatus.REJECTED.getDisplayName(),
-                "죄송합니다", teamLeader.toString(), FIXED_TIME
+                "죄송합니다", teamLeader.getName(), FIXED_TIME
             );
             when(joinWaitingMapper.toJoinWaitingResponseDto(joinWaiting)).thenReturn(expected);
 
@@ -412,9 +412,9 @@ public class JoinWaitingServiceTest {
                 .thenReturn(Optional.of(joinWaiting));
 
             JoinWaitingResponseDto expected = new JoinWaitingResponseDto(
-                JOIN_WAITING_ID, TEAM_ID, applicantId,
+                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, applicantId,
                 JoinWaitingStatus.CANCELED.getDisplayName(),
-                "개인 사정으로 취소합니다.", applicant.toString(), FIXED_TIME
+                "개인 사정으로 취소합니다.", applicant.getName(), FIXED_TIME
             );
             when(joinWaitingMapper.toJoinWaitingResponseDto(joinWaiting)).thenReturn(expected);
 
@@ -444,11 +444,11 @@ public class JoinWaitingServiceTest {
             Page<JoinWaiting> joinWaitingPage = new PageImpl<>(joinWaitingList, pageRequest, 2);
 
             JoinWaitingResponseDto responseDto1 = new JoinWaitingResponseDto(
-                1L, TEAM_ID, applicant.getId(), JoinWaitingStatus.PENDING.getDisplayName(), null,
+                1L, applicant.getName(), TEAM_ID, applicant.getId(), JoinWaitingStatus.PENDING.getDisplayName(), null,
                 null, null
             );
             JoinWaitingResponseDto responseDto2 = new JoinWaitingResponseDto(
-                2L, TEAM_ID, anotherUser.getId(), JoinWaitingStatus.PENDING.getDisplayName(), null,
+                2L, anotherUser.getName(), TEAM_ID, anotherUser.getId(), JoinWaitingStatus.PENDING.getDisplayName(), null,
                 null, null
             );
 
@@ -498,12 +498,12 @@ public class JoinWaitingServiceTest {
             Page<JoinWaiting> joinWaitingPage = new PageImpl<>(joinWaitingList, pageRequest, 2);
 
             JoinWaitingResponseDto responseDto1 = new JoinWaitingResponseDto(
-                1L, 1L, applicantId, JoinWaitingStatus.PENDING.getDisplayName(),
+                1L, applicant.getName(), 1L, applicantId, JoinWaitingStatus.PENDING.getDisplayName(),
                 "저 잘 뜁니다 1", null, null
             );
 
             JoinWaitingResponseDto responseDto2 = new JoinWaitingResponseDto(
-                2L, 2L, applicantId, JoinWaitingStatus.PENDING.getDisplayName(),
+                2L, applicant.getName(), 2L, applicantId, JoinWaitingStatus.PENDING.getDisplayName(),
                 "저 잘 뜁니다 2", null, null
             );
 


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지
- 프론트 UX 피드백 적용
  - JoinWaitingResponseDto에 신청자 이름 추가
  - decidedBy에 결정자 이름으로 변경

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
❌ 

---

*PR 확인 부탁드려요! 🙏*