### PR TITLE
refactor(join-waiting): 응답 DTO에 teamName 추가 및 Mapper/Test 반영

### DIFF
--- a/src/main/java/com/shootdoori/match/dto/JoinWaitingMapper.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinWaitingMapper.java
@@ -10,6 +10,7 @@ public class JoinWaitingMapper {
             joinWaiting.getId(),
             joinWaiting.getApplicant().getName(),
             joinWaiting.getTeam().getTeamId(),
+            joinWaiting.getTeam().getTeamName().name(),
             joinWaiting.getApplicant().getId(),
             joinWaiting.getStatus().getDisplayName(),
             joinWaiting.getDecisionReason(),

--- a/src/main/java/com/shootdoori/match/dto/JoinWaitingResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/JoinWaitingResponseDto.java
@@ -2,8 +2,14 @@ package com.shootdoori.match.dto;
 
 import java.time.LocalDateTime;
 
-public record JoinWaitingResponseDto(Long id, String applicantName, Long teamId, Long applicantId, String status,
-                                   String decisionReason, String decidedBy,
-                                   LocalDateTime decidedAt) {
+public record JoinWaitingResponseDto(Long id,
+                                     String applicantName,
+                                     Long teamId,
+                                     String teamName,
+                                     Long applicantId,
+                                     String status,
+                                     String decisionReason,
+                                     String decidedBy,
+                                     LocalDateTime decidedAt) {
 
 }

--- a/src/test/java/com/shootdoori/joinWaiting/JoinWaitingServiceTest.java
+++ b/src/test/java/com/shootdoori/joinWaiting/JoinWaitingServiceTest.java
@@ -164,7 +164,7 @@ public class JoinWaitingServiceTest {
             JoinWaiting joinWaiting = JoinWaiting.create(team, applicant, "파트라슈처럼 뛰겠습니다.");
 
             JoinWaitingResponseDto expected = new JoinWaitingResponseDto(
-                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, applicantId,
+                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, team.getTeamName().name(), applicantId,
                 JoinWaitingStatus.PENDING.getDisplayName(),
                 null, null, null
             );
@@ -281,7 +281,7 @@ public class JoinWaitingServiceTest {
                 .thenReturn(false);
 
             JoinWaitingResponseDto expected = new JoinWaitingResponseDto(
-                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, applicantId,
+                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, team.getTeamName().name(), applicantId,
                 JoinWaitingStatus.APPROVED.getDisplayName(),
                 "승인합니다", teamLeader.getName(), FIXED_TIME
             );
@@ -375,7 +375,7 @@ public class JoinWaitingServiceTest {
                 .thenReturn(Optional.of(joinWaiting));
 
             JoinWaitingResponseDto expected = new JoinWaitingResponseDto(
-                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, applicantId,
+                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, team.getTeamName().name(), applicantId,
                 JoinWaitingStatus.REJECTED.getDisplayName(),
                 "죄송합니다", teamLeader.getName(), FIXED_TIME
             );
@@ -412,7 +412,7 @@ public class JoinWaitingServiceTest {
                 .thenReturn(Optional.of(joinWaiting));
 
             JoinWaitingResponseDto expected = new JoinWaitingResponseDto(
-                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, applicantId,
+                JOIN_WAITING_ID, applicant.getName(), TEAM_ID, team.getTeamName().name(), applicantId,
                 JoinWaitingStatus.CANCELED.getDisplayName(),
                 "개인 사정으로 취소합니다.", applicant.getName(), FIXED_TIME
             );
@@ -444,11 +444,11 @@ public class JoinWaitingServiceTest {
             Page<JoinWaiting> joinWaitingPage = new PageImpl<>(joinWaitingList, pageRequest, 2);
 
             JoinWaitingResponseDto responseDto1 = new JoinWaitingResponseDto(
-                1L, applicant.getName(), TEAM_ID, applicant.getId(), JoinWaitingStatus.PENDING.getDisplayName(), null,
+                1L, applicant.getName(), TEAM_ID, team.getTeamName().name(), applicant.getId(), JoinWaitingStatus.PENDING.getDisplayName(), null,
                 null, null
             );
             JoinWaitingResponseDto responseDto2 = new JoinWaitingResponseDto(
-                2L, anotherUser.getName(), TEAM_ID, anotherUser.getId(), JoinWaitingStatus.PENDING.getDisplayName(), null,
+                2L, anotherUser.getName(), TEAM_ID, team.getTeamName().name(), anotherUser.getId(), JoinWaitingStatus.PENDING.getDisplayName(), null,
                 null, null
             );
 
@@ -498,12 +498,12 @@ public class JoinWaitingServiceTest {
             Page<JoinWaiting> joinWaitingPage = new PageImpl<>(joinWaitingList, pageRequest, 2);
 
             JoinWaitingResponseDto responseDto1 = new JoinWaitingResponseDto(
-                1L, applicant.getName(), 1L, applicantId, JoinWaitingStatus.PENDING.getDisplayName(),
+                1L, applicant.getName(), 1L, team.getTeamName().name(), applicantId, JoinWaitingStatus.PENDING.getDisplayName(),
                 "저 잘 뜁니다 1", null, null
             );
 
             JoinWaitingResponseDto responseDto2 = new JoinWaitingResponseDto(
-                2L, applicant.getName(), 2L, applicantId, JoinWaitingStatus.PENDING.getDisplayName(),
+                2L, applicant.getName(), 2L, anotherTeam.getTeamName().name(), applicantId, JoinWaitingStatus.PENDING.getDisplayName(),
                 "저 잘 뜁니다 2", null, null
             );
 


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지
- 응답 DTO에 teamName 추가 및 Mapper/Test 반영 (사용자별 가입 신청 페이징 조회에서 팀 이름 보이지 않아 불편하다는 피드백)

---

## 📷 스크린샷
<img width="517" height="505" alt="image" src="https://github.com/user-attachments/assets/024b0302-a02a-40f1-b85f-c3f54bec7854" />


---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감 (모든 테스트 통과)
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
❌ 

---

*PR 확인 부탁드려요! 🙏*