### PR TITLE
feat : 매치 생성에 대해 취소 처리, 내가 속한 팀의 매치 생성 내역 보기, 매치 생성시 리더임을 확인하는 부분 추가 및 리팩토링 etc

### DIFF
--- a/src/main/java/com/shootdoori/match/controller/MatchCreateController.java
+++ b/src/main/java/com/shootdoori/match/controller/MatchCreateController.java
@@ -2,9 +2,13 @@ package com.shootdoori.match.controller;
 
 import com.shootdoori.match.dto.MatchCreateRequestDto;
 import com.shootdoori.match.dto.MatchCreateResponseDto;
-import com.shootdoori.match.entity.User;
+import com.shootdoori.match.dto.MatchWaitingCancelResponseDto;
+import com.shootdoori.match.dto.MatchWaitingResponseDto;
 import com.shootdoori.match.resolver.LoginUser;
 import com.shootdoori.match.service.MatchCreateService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,4 +30,23 @@ public class MatchCreateController {
     MatchCreateResponseDto response = matchCreateService.createMatch(loginUserId, matchCreateRequestDto);
     return ResponseEntity.ok(response);
   }
+
+  @PatchMapping("/waiting/{matchWaitingId}/cancel")
+  public ResponseEntity<MatchWaitingCancelResponseDto> cancelMatchWaiting(
+    @LoginUser Long loginUserId,
+    @PathVariable Long matchWaitingId
+  ) {
+    MatchWaitingCancelResponseDto response = matchCreateService.cancelMatchWaiting(loginUserId, matchWaitingId);
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/waiting/me")
+  public ResponseEntity<Slice<MatchWaitingResponseDto>> getMyWaitingMatches(
+    @LoginUser Long loginUserId,
+    @PageableDefault(size = 10, sort = "createdAt", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable
+  ) {
+    Slice<MatchWaitingResponseDto> response = matchCreateService.getMyWaitingMatches(loginUserId, pageable);
+    return ResponseEntity.ok(response);
+  }
+
 }

--- a/src/main/java/com/shootdoori/match/dto/MatchCreateResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/MatchCreateResponseDto.java
@@ -1,11 +1,14 @@
 package com.shootdoori.match.dto;
 
 import com.shootdoori.match.entity.MatchWaitingStatus;
+import com.shootdoori.match.value.TeamName;
+
 import java.time.LocalDateTime;
 
 public record MatchCreateResponseDto(
     Long waitingId,
     Long teamId,
+    TeamName teamName,
     MatchWaitingStatus status,
     LocalDateTime expiresAt
 ) {

--- a/src/main/java/com/shootdoori/match/dto/MatchWaitingCancelResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/MatchWaitingCancelResponseDto.java
@@ -1,0 +1,15 @@
+package com.shootdoori.match.dto;
+
+import com.shootdoori.match.entity.MatchWaitingStatus;
+import com.shootdoori.match.value.TeamName;
+
+import java.time.LocalDateTime;
+
+public record MatchWaitingCancelResponseDto(
+  Long waitingId,
+  Long teamId,
+  TeamName teamName,
+  MatchWaitingStatus status,
+  LocalDateTime expiresAt
+) {
+}

--- a/src/main/java/com/shootdoori/match/dto/MatchWaitingResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/MatchWaitingResponseDto.java
@@ -1,5 +1,6 @@
 package com.shootdoori.match.dto;
 
+import com.shootdoori.match.entity.MatchWaiting;
 import com.shootdoori.match.entity.MatchWaitingStatus;
 import com.shootdoori.match.entity.SkillLevel;
 import com.shootdoori.match.value.TeamName;
@@ -22,4 +23,22 @@ public record MatchWaitingResponseDto(
   String message,
   MatchWaitingStatus status,
   LocalDateTime expiresAt
-) {}
+) {
+  public static MatchWaitingResponseDto from(MatchWaiting mw) {
+    return new MatchWaitingResponseDto(
+      mw.getWaitingId(),
+      mw.getTeam().getTeamId(),
+      mw.getTeam().getTeamName(),
+      mw.getPreferredDate(),
+      mw.getPreferredTimeStart(),
+      mw.getPreferredTimeEnd(),
+      mw.getPreferredVenue().getVenueId(),
+      mw.getSkillLevelMin(),
+      mw.getSkillLevelMax(),
+      mw.getUniversityOnly(),
+      mw.getMessage(),
+      mw.getMatchWaitingStatus(),
+      mw.getExpiresAt()
+    );
+  }
+}

--- a/src/main/java/com/shootdoori/match/entity/MatchWaiting.java
+++ b/src/main/java/com/shootdoori/match/entity/MatchWaiting.java
@@ -131,7 +131,7 @@ public class MatchWaiting extends DateEntity{
     return message;
   }
 
-  public MatchWaitingStatus getMatchRequestStatus() {
+  public MatchWaitingStatus getMatchWaitingStatus() {
     return status;
   }
 
@@ -142,4 +142,9 @@ public class MatchWaiting extends DateEntity{
   public void updateWaitingStatus(MatchWaitingStatus status){
     this.status = status;
   }
+
+  public void cancelMatchWaiting(){
+    this.status = MatchWaitingStatus.CANCELED;
+  }
+
 }

--- a/src/main/java/com/shootdoori/match/repository/MatchWaitingRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/MatchWaitingRepository.java
@@ -26,5 +26,13 @@ public interface MatchWaitingRepository extends JpaRepository<MatchWaiting, Long
         @Param("lastTime") LocalTime lastTime,
         Pageable pageable
     );
+
+    @Query("SELECT mw FROM MatchWaiting mw " +
+        "WHERE mw.team.id = :teamId " +
+        "ORDER BY mw.createdAt DESC")
+    Slice<MatchWaiting> findMyTeamMatchWaitingHistory(
+        @Param("teamId") Long teamId,
+        Pageable pageable
+    );
 }
 

--- a/src/main/java/com/shootdoori/match/service/MatchRequestService.java
+++ b/src/main/java/com/shootdoori/match/service/MatchRequestService.java
@@ -65,7 +65,7 @@ public class MatchRequestService {
         mw.getSkillLevelMax(),
         mw.getUniversityOnly(),
         mw.getMessage(),
-        mw.getMatchRequestStatus(),
+        mw.getMatchWaitingStatus(),
         mw.getExpiresAt()
       ));
   }

--- a/src/test/java/com/shootdoori/match/entity/MatchWaitingTest.java
+++ b/src/test/java/com/shootdoori/match/entity/MatchWaitingTest.java
@@ -57,6 +57,6 @@ class MatchWaitingTest {
 
     matchWaiting.updateWaitingStatus(MatchWaitingStatus.MATCHED);
 
-    assertEquals(MatchWaitingStatus.MATCHED, matchWaiting.getMatchRequestStatus());
+    assertEquals(MatchWaitingStatus.MATCHED, matchWaiting.getMatchWaitingStatus());
   }
 }

--- a/src/test/java/com/shootdoori/match/service/MatchCreateServiceTest.java
+++ b/src/test/java/com/shootdoori/match/service/MatchCreateServiceTest.java
@@ -6,7 +6,10 @@ import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
 import com.shootdoori.match.dto.MatchCreateRequestDto;
 import com.shootdoori.match.dto.MatchCreateResponseDto;
+import com.shootdoori.match.dto.MatchWaitingCancelResponseDto;
+import com.shootdoori.match.dto.MatchWaitingResponseDto;
 import com.shootdoori.match.entity.*;
+import com.shootdoori.match.exception.NoPermissionException;
 import com.shootdoori.match.exception.NotFoundException;
 import com.shootdoori.match.repository.*;
 
@@ -21,6 +24,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -46,6 +51,7 @@ class MatchCreateServiceTest {
   private TeamMemberRepository teamMemberRepository;
 
   private User savedCaptain;
+  private User savedMember;
   private Team savedTeam;
   private Venue savedVenue;
 
@@ -70,6 +76,21 @@ class MatchCreateServiceTest {
     );
     savedCaptain = profileRepository.save(captain);
 
+    User member = User.create(
+      "선원준 팀 멤버 1",
+      "프로",
+      "swj1@naver.com",
+      "swj1@kangwon.ac.kr",
+      "12345678",
+      "010-1234-9999",
+      "공격수",
+      "강원대학교",
+      "컴퓨터공학과",
+      "20",
+      "테스트 멤버입니다."
+    );
+    savedMember = profileRepository.save(member);
+
     Team team = new Team(
       "팀 선원준",
       savedCaptain,
@@ -82,6 +103,9 @@ class MatchCreateServiceTest {
 
     TeamMember captainMember = new TeamMember(savedTeam, savedCaptain, TeamMemberRole.LEADER);
     teamMemberRepository.save(captainMember);
+
+    TeamMember normalMember = new TeamMember(savedTeam, savedMember, TeamMemberRole.MEMBER);
+    teamMemberRepository.save(normalMember);
 
     Venue venue = new Venue(
       "강원대 대운동장",
@@ -174,6 +198,102 @@ class MatchCreateServiceTest {
     assertThat(match.getSkillLevelMax()).isEqualTo(SkillLevel.PRO);
     assertThat(match.getUniversityOnly()).isFalse();
     assertThat(match.getMessage()).isEqualTo(MESSAGE);
-    assertThat(match.getMatchRequestStatus()).isEqualTo(MatchWaitingStatus.WAITING);
+    assertThat(match.getMatchWaitingStatus()).isEqualTo(MatchWaitingStatus.WAITING);
+  }
+
+  @Test
+  @DisplayName("리더가 매치 대기 취소 시 상태가 CANCELED로 변경됨")
+  void cancelMatchWaiting_asLeader_success() {
+    // given - 먼저 매치 생성
+    MatchCreateRequestDto dto = new MatchCreateRequestDto(
+      LocalDate.now(),
+      LocalTime.of(10, 0),
+      LocalTime.of(12, 0),
+      savedVenue.getVenueId(),
+      SkillLevel.AMATEUR,
+      SkillLevel.PRO,
+      false,
+      MESSAGE
+    );
+    MatchCreateResponseDto created = matchCreateService.createMatch(savedCaptain.getId(), dto);
+
+    // when - 리더가 취소 요청
+    MatchWaitingCancelResponseDto canceled = matchCreateService.cancelMatchWaiting(savedCaptain.getId(), created.waitingId());
+
+    // then - 상태 변경 확인
+    assertThat(canceled).isNotNull();
+    assertThat(canceled.teamId()).isEqualTo(savedTeam.getTeamId());
+    assertThat(canceled.status()).isEqualTo(MatchWaitingStatus.CANCELED);
+
+    // DB에 실제로 반영되었는지 확인
+    MatchWaiting found = matchWaitingRepository.findById(created.waitingId()).orElseThrow();
+    assertThat(found.getMatchWaitingStatus()).isEqualTo(MatchWaitingStatus.CANCELED);
+  }
+
+  @Test
+  @DisplayName("일반 멤버가 매치 대기 취소 시 NoPermissionException 발생")
+  void cancelMatchWaiting_asMember_fail() {
+    // given - 먼저 매치 생성
+    MatchCreateRequestDto dto = new MatchCreateRequestDto(
+      LocalDate.now(),
+      LocalTime.of(10, 0),
+      LocalTime.of(12, 0),
+      savedVenue.getVenueId(),
+      SkillLevel.AMATEUR,
+      SkillLevel.PRO,
+      false,
+      MESSAGE
+    );
+    MatchCreateResponseDto created = matchCreateService.createMatch(savedCaptain.getId(), dto);
+
+    // when / then - 멤버가 취소 시 예외 발생
+    assertThatThrownBy(() -> matchCreateService.cancelMatchWaiting(savedMember.getId(), created.waitingId()))
+      .isInstanceOf(NoPermissionException.class);
+
+    // DB에 상태가 여전히 WAITING인지 확인
+    MatchWaiting found = matchWaitingRepository.findById(created.waitingId()).orElseThrow();
+    assertThat(found.getMatchWaitingStatus()).isEqualTo(MatchWaitingStatus.WAITING);
+  }
+
+  @Test
+  @DisplayName("내 팀의 매치 대기 목록 조회 - 최신순 정렬 확인")
+  void getMyWaitingMatches_orderByCreatedAtDesc() throws InterruptedException {
+    // given - 먼저 생성된 매치 생성
+    MatchCreateRequestDto dto1 = new MatchCreateRequestDto(
+      LocalDate.now(),
+      LocalTime.of(10, 0),
+      LocalTime.of(12, 0),
+      savedVenue.getVenueId(),
+      SkillLevel.AMATEUR,
+      SkillLevel.PRO,
+      false,
+      "먼저 생성된 매치"
+    );
+    MatchCreateResponseDto match1 = matchCreateService.createMatch(savedCaptain.getId(), dto1);
+
+    // 잠깐 기다려서 createdAt이 달라지도록 함
+    Thread.sleep(100);
+
+    // 나중에 생성된 매치
+    MatchCreateRequestDto dto2 = new MatchCreateRequestDto(
+      LocalDate.now(),
+      LocalTime.of(14, 0),
+      LocalTime.of(16, 0),
+      savedVenue.getVenueId(),
+      SkillLevel.AMATEUR,
+      SkillLevel.PRO,
+      false,
+      "나중에 생성된 매치"
+    );
+    MatchCreateResponseDto match2 = matchCreateService.createMatch(savedCaptain.getId(), dto2);
+
+    // when - 내 팀 매치 대기 조회
+    Pageable pageable = org.springframework.data.domain.PageRequest.of(0, 10);
+    Slice<MatchWaitingResponseDto> response = matchCreateService.getMyWaitingMatches(savedCaptain.getId(), pageable);
+
+    assertThat(response).isNotEmpty();
+    assertThat(response.getContent()).hasSize(2);
+    assertThat(response.getContent().get(0).waitingId()).isEqualTo(match2.waitingId()); // 최신이 첫 번째
+    assertThat(response.getContent().get(1).waitingId()).isEqualTo(match1.waitingId()); // 오래된 것이 두 번째
   }
 }

--- a/src/test/java/com/shootdoori/match/service/MatchRequestServiceTest.java
+++ b/src/test/java/com/shootdoori/match/service/MatchRequestServiceTest.java
@@ -371,7 +371,7 @@ class MatchRequestServiceTest {
     assertThat(updatedRequest2.getStatus()).isEqualTo(MatchRequestStatus.REJECTED);
 
     // 3) waiting 상태 MATCHED
-    assertThat(updatedWaiting.getMatchRequestStatus()).isEqualTo(MatchWaitingStatus.MATCHED);
+    assertThat(updatedWaiting.getMatchWaitingStatus()).isEqualTo(MatchWaitingStatus.MATCHED);
 
     // 4) Match 생성 확인
     assertThat(match.getTeam1().getTeamId()).isEqualTo(targetTeam.getTeamId());


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
<!-- 이슈가 있다면 링크해주세요! -->
x

---

## 🛠️ 뭘 했는지
- [feat] 매치 생성에 대한 취소 처리 (리더 여부 확인)
- [feat] 내가 속한 팀의 매치 생성 내역 보기
- [feat] 기존 매치 생성 기능에 대해 리더임을 검증하지 않았던 부분을 검증하도록 수정

- [test] 이번 개발 부분에 대한 테스트 코드 작성

- [refactor] MatchWaiting의 status를 가져오는 getter 메소드의 이름이 getRequestStatus 로 오타 부분 수정
- [refactor] MatchCreateResponseDto에 팀 이름까지 반환하도록 수정(프론트 UX) 
- [refactor] MatchWaitingResponseDto에 팩토리 메소드 추가

---

## 📷 스크린샷
x

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
x

---

*PR 확인 부탁드려요! 🙏*