### PR TITLE
refactor: 리프레시 토큰 응답 방식을 JSON으로 수정

### DIFF
--- a/src/main/java/com/shootdoori/match/controller/LoginController.java
+++ b/src/main/java/com/shootdoori/match/controller/LoginController.java
@@ -69,20 +69,4 @@ public class LoginController {
 
         return ResponseEntity.ok().build();
     }
-
-//    private void expireRefreshTokenCookie(HttpServletResponse response) {
-//        Cookie cookie = new Cookie("refreshToken", "deleted");
-//        cookie.setMaxAge(0);
-//        cookie.setPath("/");
-//        response.addCookie(cookie);
-//    }
-//
-//    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
-//        Cookie cookie = new Cookie("refreshToken", refreshToken);
-//        cookie.setHttpOnly(true);
-//        cookie.setSecure(true);
-//        cookie.setPath("/");
-//        cookie.setMaxAge(COOKIE_MAX_AGE);
-//        response.addCookie(cookie);
-//    }
 }

--- a/src/main/java/com/shootdoori/match/controller/LoginController.java
+++ b/src/main/java/com/shootdoori/match/controller/LoginController.java
@@ -1,15 +1,10 @@
 package com.shootdoori.match.controller;
 
-import com.shootdoori.match.dto.AuthToken;
-import com.shootdoori.match.dto.AuthTokenResponse;
-import com.shootdoori.match.dto.LoginRequest;
-import com.shootdoori.match.dto.ProfileCreateRequest;
+import com.shootdoori.match.dto.*;
 import com.shootdoori.match.resolver.LoginUser;
 import com.shootdoori.match.service.AuthService;
 import com.shootdoori.match.service.TokenRefreshService;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,7 +14,8 @@ public class LoginController {
     private final AuthService authService;
     private final TokenRefreshService tokenRefreshService;
 
-    private final int COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
+    private static final long ACCESS_TOKEN_EXPIRES_IN_SECONDS = 30 * 60L;
+    private static final long REFRESH_TOKEN_EXPIRES_IN_SECONDS = 30 * 24 * 60 * 60L;
 
     public LoginController(AuthService authService, TokenRefreshService tokenRefreshService) {
         this.authService = authService;
@@ -29,73 +25,64 @@ public class LoginController {
     @PostMapping("/login")
     public ResponseEntity<AuthTokenResponse> login(
         @RequestBody LoginRequest loginRequest,
-        HttpServletRequest request,
-        HttpServletResponse response
+        HttpServletRequest request
     ) {
         AuthToken token = authService.login(loginRequest, request);
-        setRefreshTokenCookie(response, token.refreshToken());
 
-        return ResponseEntity.ok(new AuthTokenResponse(token.accessToken()));
+        return ResponseEntity.ok(new AuthTokenResponse(
+                token.accessToken(), token.refreshToken(), ACCESS_TOKEN_EXPIRES_IN_SECONDS, REFRESH_TOKEN_EXPIRES_IN_SECONDS));
     }
 
     @PostMapping("/register")
     public ResponseEntity<AuthTokenResponse> register(
         @RequestBody ProfileCreateRequest profileCreateRequest,
-        HttpServletRequest request,
-        HttpServletResponse response
+        HttpServletRequest request
     ) {
         AuthToken token = authService.register(profileCreateRequest, request);
-        setRefreshTokenCookie(response, token.refreshToken());
 
-        return ResponseEntity.ok(new AuthTokenResponse(token.accessToken()));
+        return ResponseEntity.ok(new AuthTokenResponse(
+                token.accessToken(), token.refreshToken(), ACCESS_TOKEN_EXPIRES_IN_SECONDS, REFRESH_TOKEN_EXPIRES_IN_SECONDS));
     }
 
     @PostMapping("/refresh")
     public ResponseEntity<AuthTokenResponse> refresh(
-        @CookieValue("refreshToken") String refreshToken,
-        HttpServletResponse response
+        @RequestBody TokenRefreshRequest token
     ) {
-        AuthToken newTokens = tokenRefreshService.refreshAccessToken(refreshToken);
-        setRefreshTokenCookie(response, newTokens.refreshToken());
+        AuthToken newTokens = tokenRefreshService.refreshAccessToken(token.refreshToken());
 
-        return ResponseEntity.ok(new AuthTokenResponse(newTokens.accessToken()));
+        return ResponseEntity.ok(new AuthTokenResponse(
+                newTokens.accessToken(), newTokens.refreshToken(), ACCESS_TOKEN_EXPIRES_IN_SECONDS, REFRESH_TOKEN_EXPIRES_IN_SECONDS));
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(
-        @CookieValue("refreshToken") String refreshToken,
-        HttpServletResponse response
-    ) {
-        authService.logout(refreshToken);
-        expireRefreshTokenCookie(response);
+    public ResponseEntity<Void> logout(@RequestBody TokenRefreshRequest token) {
+        authService.logout(token.refreshToken());
 
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/logout-all")
     public ResponseEntity<Void> logoutAll(
-        @LoginUser Long userId,
-        HttpServletResponse response
+        @LoginUser Long userId
     ) {
         authService.logoutAll(userId);
-        expireRefreshTokenCookie(response);
 
         return ResponseEntity.ok().build();
     }
 
-    private void expireRefreshTokenCookie(HttpServletResponse response) {
-        Cookie cookie = new Cookie("refreshToken", "deleted");
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
-        response.addCookie(cookie);
-    }
-
-    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
-        Cookie cookie = new Cookie("refreshToken", refreshToken);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(COOKIE_MAX_AGE);
-        response.addCookie(cookie);
-    }
+//    private void expireRefreshTokenCookie(HttpServletResponse response) {
+//        Cookie cookie = new Cookie("refreshToken", "deleted");
+//        cookie.setMaxAge(0);
+//        cookie.setPath("/");
+//        response.addCookie(cookie);
+//    }
+//
+//    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+//        Cookie cookie = new Cookie("refreshToken", refreshToken);
+//        cookie.setHttpOnly(true);
+//        cookie.setSecure(true);
+//        cookie.setPath("/");
+//        cookie.setMaxAge(COOKIE_MAX_AGE);
+//        response.addCookie(cookie);
+//    }
 }

--- a/src/main/java/com/shootdoori/match/dto/AuthTokenResponse.java
+++ b/src/main/java/com/shootdoori/match/dto/AuthTokenResponse.java
@@ -1,4 +1,9 @@
 package com.shootdoori.match.dto;
 
-public record AuthTokenResponse(String accessToken) {
+public record AuthTokenResponse(
+        String accessToken,
+        String refreshToken,
+        long accessTokenExpiresIn,
+        long refreshTokenExpiresIn
+) {
 }

--- a/src/main/java/com/shootdoori/match/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/shootdoori/match/dto/TokenRefreshRequest.java
@@ -1,0 +1,4 @@
+package com.shootdoori.match.dto;
+
+public record TokenRefreshRequest(String refreshToken) {
+}


### PR DESCRIPTION
# 🔥 Pull Request

---

## 🛠️ 뭘 했는지
- 기존 구현: 액세스/리프레시 토큰 쌍을 발급한 후, 응답에는 액세스 토큰만 포함
- **변경**: 리프레시 토큰도 액세스 토큰 및 유효기간과 함께 JSON 응답으로 반환
  -  쿠키에 담던 리프레시 토큰을 AuthTokenResponse DTO를 통해 반환하도록 변경 (앱 환경)

---
## 🛠️ 테스트 코드 
- 쿠키 기반 검증 로직 → JSON 응답 기반 검증 로직으로 수정

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] match.test 모두 통과 확인

---

## 👀 특히 봐주세요!
토큰을 갱신 및 로그아웃하기 위해 리프레시 토큰을 `@RequestBody`로 받는데 이때 DTO 의 이름이 어색하지 않은지 봐주세요!
(RefreshToken이라는 이름을 가진 엔티티가 이미 있기 때문에..)

---

*PR 확인 부탁드려요! 🙏*