### PR TITLE
feat(match_request) : 자신이 속한 팀의 매치 요청 내역을 최신순으로 보여주는 기능 추가

### DIFF
--- a/src/main/java/com/shootdoori/match/controller/MatchRequestController.java
+++ b/src/main/java/com/shootdoori/match/controller/MatchRequestController.java
@@ -87,4 +87,14 @@ public class MatchRequestController {
             requestId);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/requests/me")
+    public ResponseEntity<Slice<MatchRequestHistoryResponseDto>> getSentRequestsByMyTeam(
+        @LoginUser Long loginUserId,
+        @PageableDefault(size = 10, sort = "requestAt", direction = org.springframework.data.domain.Sort.Direction.DESC)
+        Pageable pageable) {
+
+        Slice<MatchRequestHistoryResponseDto> response = matchRequestService.getSentRequestsByMyTeam(loginUserId, pageable);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/shootdoori/match/dto/MatchRequestHistoryResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/MatchRequestHistoryResponseDto.java
@@ -1,0 +1,18 @@
+package com.shootdoori.match.dto;
+
+import com.shootdoori.match.entity.match.request.MatchRequestStatus;
+import com.shootdoori.match.value.TeamName;
+
+import java.time.LocalDateTime;
+
+public record MatchRequestHistoryResponseDto(
+    Long requestId,
+    Long requestTeamId,
+    TeamName requestTeamName,
+    Long targetTeamId,
+    TeamName targetTeamName,
+    String requestMessage,
+    MatchRequestStatus status,
+    LocalDateTime requestAt
+) {
+}

--- a/src/main/java/com/shootdoori/match/repository/MatchRequestRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/MatchRequestRepository.java
@@ -26,4 +26,10 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
         "AND mr.status = com.shootdoori.match.entity.match.request.MatchRequestStatus.PENDING " +
         "ORDER BY mr.requestAt ASC ")
     Slice<MatchRequest> findPendingRequestsByTargetTeam(@Param("targetTeamId") Long targetTeamId, Pageable pageable);
+
+    @Query("SELECT mr FROM MatchRequest mr " +
+        "WHERE mr.requestTeam.teamId = :requestTeamId " +
+        "ORDER BY mr.requestAt DESC")
+    Slice<MatchRequest> findSentRequestsByTeam(@Param("requestTeamId") Long requestTeamId,
+                                               Pageable pageable);
 }

--- a/src/main/java/com/shootdoori/match/service/MatchRequestService.java
+++ b/src/main/java/com/shootdoori/match/service/MatchRequestService.java
@@ -257,4 +257,26 @@ public class MatchRequestService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public Slice<MatchRequestHistoryResponseDto> getSentRequestsByMyTeam(Long loginUserId,
+                                                          Pageable pageable) {
+        TeamMember teamMember = teamMemberRepository.findByUser_Id(loginUserId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.TEAM_MEMBER_NOT_FOUND));
+
+        Long myTeamId = teamMember.getTeam().getTeamId();
+
+        Slice<MatchRequest> requests = matchRequestRepository.findSentRequestsByTeam(myTeamId, pageable);
+
+        return requests.map(mr -> new MatchRequestHistoryResponseDto(
+            mr.getRequestId(),
+            mr.getRequestTeam().getTeamId(),
+            mr.getRequestTeam().getTeamName(),
+            mr.getTargetTeam().getTeamId(),
+            mr.getTargetTeam().getTeamName(),
+            mr.getRequestMessage(),
+            mr.getStatus(),
+            mr.getRequestAt()
+        ));
+    }
+
 }


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
X

---

## 🛠️ 뭘 했는지
- 매치 요청에 대해 취소하기 위해, 내가 속한 팀에 대해서 매치 요청 내역을 보여주는 기능을 추가하였습니다
  - Controller, Serice, Repository, DTO 작성
- 해당 기능에 대해 테스트 코드 작성

---

## 📷 스크린샷
X

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
x
---

*PR 확인 부탁드려요! 🙏*