### PR TITLE
feat: 팀원 생성 및 가입 요청 생성/승인 시, 해당 유저가 가입 팀 존재하는지 검증하는 로직 추가

### DIFF
--- a/src/main/java/com/shootdoori/match/exception/common/ErrorCode.java
+++ b/src/main/java/com/shootdoori/match/exception/common/ErrorCode.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
     ALREADY_TEAM_MEMBER("이미 해당 팀의 멤버입니다.", HttpStatus.CONFLICT),
+    ALREADY_OTHER_TEAM_MEMBER("이미 다른 팀에 소속되어 있습니다.", HttpStatus.CONFLICT),
     CAPTAIN_NOT_FOUND("팀장 정보가 없습니다.", HttpStatus.NOT_FOUND),
     DIFFERENT_UNIVERSITY("팀 소속 대학과 동일한 대학의 사용자만 가입할 수 있습니다.", HttpStatus.FORBIDDEN),
     DUPLICATED_USER("이미 존재하는 사용자입니다.", HttpStatus.CONFLICT),

--- a/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/TeamMemberRepository.java
@@ -17,4 +17,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     Optional<TeamMember> findByIdAndTeam_TeamId(Long teamMemberId, Long teamId);
 
     Optional<TeamMember> findByUser_Id(Long userId);
+
+    boolean existsByUser_Id(Long userId);
 }

--- a/src/main/java/com/shootdoori/match/service/JoinWaitingService.java
+++ b/src/main/java/com/shootdoori/match/service/JoinWaitingService.java
@@ -54,6 +54,10 @@ public class JoinWaitingService {
 
         team.validateSameUniversity(applicant);
 
+        if (teamMemberRepository.existsByUser_Id(applicantId)) {
+            throw new DuplicatedException(ErrorCode.ALREADY_OTHER_TEAM_MEMBER);
+        }
+
         if (teamMemberRepository.existsByTeam_TeamIdAndUser_Id(teamId, applicantId)) {
             throw new DuplicatedException(ErrorCode.ALREADY_TEAM_MEMBER);
         }
@@ -87,6 +91,10 @@ public class JoinWaitingService {
 
         Team team = joinWaiting.getTeam();
         User applicant = joinWaiting.getApplicant();
+
+        if (teamMemberRepository.existsByUser_Id(applicant.getId())) {
+            throw new DuplicatedException(ErrorCode.ALREADY_OTHER_TEAM_MEMBER);
+        }
 
         if (teamMemberRepository.existsByTeam_TeamIdAndUser_Id(teamId, applicant.getId())) {
             throw new DuplicatedException(ErrorCode.ALREADY_TEAM_MEMBER);

--- a/src/main/java/com/shootdoori/match/service/TeamMemberService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamMemberService.java
@@ -57,6 +57,10 @@ public class TeamMemberService {
         User user = profileRepository.findById(userId).orElseThrow(
             () -> new NotFoundException(ErrorCode.USER_NOT_FOUND, String.valueOf(userId)));
 
+        if (teamMemberRepository.existsByUser_Id(userId)) {
+            throw new DuplicatedException(ErrorCode.ALREADY_OTHER_TEAM_MEMBER);
+        }
+
         if (teamMemberRepository.existsByTeam_TeamIdAndUser_Id(teamId, userId)) {
             throw new DuplicatedException(ErrorCode.ALREADY_TEAM_MEMBER);
         }

--- a/src/test/java/com/shootdoori/teamMember/TeamMemberServiceTest.java
+++ b/src/test/java/com/shootdoori/teamMember/TeamMemberServiceTest.java
@@ -227,6 +227,25 @@ public class TeamMemberServiceTest {
             assertThatThrownBy(() -> teamMemberService.create(TEAM_ID, requestDto, captain.getId()))
                 .isInstanceOf(DuplicatedException.class);
         }
+
+        @Test
+        @DisplayName("create - 다른 팀에 이미 소속된 경우 예외")
+        void create_alreadyOtherTeamMember_throws() {
+            // given
+            TeamMemberRequestDto requestDto = new TeamMemberRequestDto(
+                USER_ID,
+                ROLE_MEMBER
+            );
+            ReflectionTestUtils.setField(captain, "id", 1L);
+
+            when(teamRepository.findById(TEAM_ID)).thenReturn(Optional.of(team));
+            when(profileRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(teamMemberRepository.existsByUser_Id(USER_ID)).thenReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> teamMemberService.create(TEAM_ID, requestDto, captain.getId()))
+                .isInstanceOf(DuplicatedException.class);
+        }
     }
 
     @Nested


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지
- 팀원 생성 및 팀원 가입 요청 생성/승인 시, 내가 속한 팀이 있는데 다른 팀에 가입하려고 하는 것을 방지하는 로직 추가

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감 (테스트 모두 통과)
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
❌ 

---

*PR 확인 부탁드려요! 🙏*