### PR TITLE
fix: 팀 멤버 삭제 시, 라인업 연관 문제를 하드 삭제로 해결

### DIFF
--- a/src/main/java/com/shootdoori/match/entity/team/TeamMember.java
+++ b/src/main/java/com/shootdoori/match/entity/team/TeamMember.java
@@ -6,6 +6,7 @@ import com.shootdoori.match.exception.common.DifferentException;
 import com.shootdoori.match.exception.common.DuplicatedException;
 import com.shootdoori.match.exception.common.ErrorCode;
 import com.shootdoori.match.exception.common.NoPermissionException;
+import com.shootdoori.match.value.LineupMembers;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -52,6 +53,9 @@ public class TeamMember {
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false, length = 20)
     private TeamMemberRole role = TeamMemberRole.MEMBER;
+
+    @Embedded
+    private LineupMembers lineupMembers = LineupMembers.empty();
 
     @Embedded
     private AuditInfo audit = new AuditInfo();
@@ -186,6 +190,8 @@ public class TeamMember {
     public boolean isSameUser(User targetUser) {
         return user.equals(targetUser);
     }
+
+    public void clearLineupMembers() { lineupMembers.clear(); }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/shootdoori/match/service/TeamMemberService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamMemberService.java
@@ -165,6 +165,8 @@ public class TeamMemberService {
             throw new NoPermissionException(ErrorCode.LEADER_CANNOT_LEAVE);
         }
 
+        loginMember.clearLineupMembers();
+
         team.removeMember(loginMember);
         teamRepository.save(team);
     }
@@ -184,6 +186,8 @@ public class TeamMemberService {
         if (!loginMember.getRole().canKick(targetMember.getRole())) {
             throw new NoPermissionException(ErrorCode.INSUFFICIENT_ROLE_FOR_KICK);
         }
+
+        targetMember.clearLineupMembers();
 
         team.removeMember(targetMember);
         teamRepository.save(team);

--- a/src/main/java/com/shootdoori/match/value/LineupMembers.java
+++ b/src/main/java/com/shootdoori/match/value/LineupMembers.java
@@ -1,0 +1,44 @@
+package com.shootdoori.match.value;
+
+import com.shootdoori.match.entity.lineup.LineupMember;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Embeddable
+public class LineupMembers {
+
+    @OneToMany(
+        mappedBy = "teamMember",
+        cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
+        orphanRemoval = true
+    )
+    private List<LineupMember> lineupMembers = new ArrayList<>();
+
+    protected LineupMembers() {
+    }
+
+    public LineupMembers(List<LineupMember> lineupMembers) {
+        this.lineupMembers = lineupMembers == null
+            ? new ArrayList<>()
+            : new ArrayList<>(lineupMembers);
+    }
+
+    public static LineupMembers empty() { return new LineupMembers(); }
+
+    public boolean isEmpty() { return lineupMembers.isEmpty(); }
+
+    public void clear() {
+        lineupMembers.clear();
+    }
+
+    public void addMember(LineupMember lineupMember) {
+        lineupMembers.add(lineupMember);
+    }
+
+    public void removeMember(LineupMember lineupMember) {
+        lineupMembers.remove(lineupMember);
+    }
+}


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지
- 팀 멤버 삭제 시, 라인업 연관 문제를 하드 삭제로 해결

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
❌ 

---

*PR 확인 부탁드려요! 🙏*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lineup member management capabilities to track team member participation in lineups.

* **Bug Fixes**
  * Fixed data integrity by ensuring lineup associations are properly cleared when members leave or are removed from teams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->