### PR TITLE
feat: 팀 삭제 제약 보강 및 가입 대기 자동 취소 도입, isMercenary 기반 조회 추가와 전체 테스트 보강

### DIFF
--- a/src/main/java/com/shootdoori/match/controller/JoinWaitingController.java
+++ b/src/main/java/com/shootdoori/match/controller/JoinWaitingController.java
@@ -77,18 +77,20 @@ public class JoinWaitingController {
     public ResponseEntity<Page<JoinWaitingResponseDto>> findPending(
         @PathVariable Long teamId,
         @RequestParam(defaultValue = "PENDING") JoinWaitingStatus status,
+        @RequestParam(defaultValue = "false") boolean isMercenary,
         @PageableDefault(size = 10, sort = "audit.createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return new ResponseEntity<>(joinWaitingService.findPending(teamId, status, pageable),
+        return new ResponseEntity<>(joinWaitingService.findPending(teamId, status, isMercenary, pageable),
             HttpStatus.OK);
     }
 
     @GetMapping("/api/users/me/join-waiting")
     public ResponseEntity<Page<JoinWaitingResponseDto>> findByApplicant(
         @LoginUser Long loginUserId,
+        @RequestParam(defaultValue = "false") boolean isMercenary,
         @PageableDefault(size = 10, sort = "audit.createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return new ResponseEntity<>(joinWaitingService.findAllByApplicantIdAndStatusIn(loginUserId, pageable),
+        return new ResponseEntity<>(joinWaitingService.findAllByApplicantIdAndStatusIn(loginUserId, isMercenary, pageable),
             HttpStatus.OK);
     }
 }

--- a/src/main/java/com/shootdoori/match/entity/team/join/JoinWaiting.java
+++ b/src/main/java/com/shootdoori/match/entity/team/join/JoinWaiting.java
@@ -168,6 +168,20 @@ public class JoinWaiting {
         this.decidedAt = LocalDateTime.now();
     }
 
+    public void cancelBySystem(String decisionReason) {
+        if (!status.isPending()) {
+            return;
+        }
+        this.status = JoinWaitingStatus.CANCELED;
+        this.decisionReason = decisionReason;
+        this.decidedBy = null;
+        this.decidedAt = LocalDateTime.now();
+    }
+
+    public boolean isPending() {
+        return status.isPending();
+    }
+
     private void verifyPending() {
         if (!this.status.isPending()) {
             throw new JoinWaitingNotPendingException();

--- a/src/main/java/com/shootdoori/match/exception/common/ErrorCode.java
+++ b/src/main/java/com/shootdoori/match/exception/common/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     CAPTAIN_NOT_FOUND("팀장 정보가 없습니다.", HttpStatus.NOT_FOUND),
     DIFFERENT_UNIVERSITY("팀 소속 대학과 동일한 대학의 사용자만 가입할 수 있습니다.", HttpStatus.FORBIDDEN),
     TEAM_REVIEW_NOT_FOUND("해당 팀 리뷰를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    TEAM_HAS_REMAINING_MEMBERS("아직 팀에 소속된 멤버가 있습니다.", HttpStatus.BAD_REQUEST),
 
     // Team Member
     ALREADY_TEAM_MEMBER("이미 해당 팀의 멤버입니다.", HttpStatus.CONFLICT),

--- a/src/main/java/com/shootdoori/match/exception/domain/team/TeamHasRemainingMembersException.java
+++ b/src/main/java/com/shootdoori/match/exception/domain/team/TeamHasRemainingMembersException.java
@@ -1,0 +1,10 @@
+package com.shootdoori.match.exception.domain.team;
+
+import com.shootdoori.match.exception.common.BusinessException;
+import com.shootdoori.match.exception.common.ErrorCode;
+
+public class TeamHasRemainingMembersException extends BusinessException {
+    public TeamHasRemainingMembersException() {
+        super(ErrorCode.TEAM_HAS_REMAINING_MEMBERS);
+    }
+}

--- a/src/main/java/com/shootdoori/match/repository/JoinWaitingRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/JoinWaitingRepository.java
@@ -27,5 +27,7 @@ public interface JoinWaitingRepository extends JpaRepository<JoinWaiting, Long> 
 
     Page<JoinWaiting> findAllByTeam_TeamIdAndStatus(Long teamId, JoinWaitingStatus status, Pageable pageable);
 
+    List<JoinWaiting> findAllByTeam_TeamIdAndStatus(Long teamId, JoinWaitingStatus status);
+
     Page<JoinWaiting> findAllByApplicant_IdAndStatusIn(Long applicantId, List<JoinWaitingStatus> statuses, Pageable pageable);
 }

--- a/src/main/java/com/shootdoori/match/repository/JoinWaitingRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/JoinWaitingRepository.java
@@ -25,9 +25,11 @@ public interface JoinWaitingRepository extends JpaRepository<JoinWaiting, Long> 
         """)
     Optional<JoinWaiting> findByIdAndTeam_TeamIdForUpdate(Long id, Long teamId);
 
-    Page<JoinWaiting> findAllByTeam_TeamIdAndStatus(Long teamId, JoinWaitingStatus status, Pageable pageable);
+    Page<JoinWaiting> findAllByTeam_TeamIdAndStatusAndIsMercenary(Long teamId,
+        JoinWaitingStatus status, boolean isMercenary, Pageable pageable);
 
     List<JoinWaiting> findAllByTeam_TeamIdAndStatus(Long teamId, JoinWaitingStatus status);
 
-    Page<JoinWaiting> findAllByApplicant_IdAndStatusIn(Long applicantId, List<JoinWaitingStatus> statuses, Pageable pageable);
+    Page<JoinWaiting> findAllByApplicant_IdAndStatusInAndIsMercenary(Long applicantId,
+        List<JoinWaitingStatus> statuses, boolean isMercenary, Pageable pageable);
 }

--- a/src/main/java/com/shootdoori/match/service/JoinWaitingService.java
+++ b/src/main/java/com/shootdoori/match/service/JoinWaitingService.java
@@ -197,4 +197,21 @@ public class JoinWaitingService {
                 pageable)
             .map(joinWaitingMapper::toJoinWaitingResponseDto);
     }
+
+    @Transactional
+    public void cancelAllPendingByTeam(Long teamId, String reason) {
+        List<JoinWaiting> pendings =
+            joinWaitingRepository.findAllByTeam_TeamIdAndStatus(teamId, JoinWaitingStatus.PENDING);
+
+        pendings.forEach(joinWaiting -> {
+            joinWaiting.cancelBySystem(reason);
+            notificationService.sendJoinCancelNotification(
+                joinWaiting.getTeam(),
+                joinWaiting.getApplicant(),
+                joinWaiting.getDecidedAt(),
+                joinWaiting.getDecisionReason(),
+                joinWaiting.isMercenary()
+            );
+        });
+    }
 }

--- a/src/main/java/com/shootdoori/match/service/JoinWaitingService.java
+++ b/src/main/java/com/shootdoori/match/service/JoinWaitingService.java
@@ -174,18 +174,19 @@ public class JoinWaitingService {
 
     @Transactional(readOnly = true)
     public Page<JoinWaitingResponseDto> findPending(Long teamId, JoinWaitingStatus status,
-        Pageable pageable) {
+        boolean isMercenary, Pageable pageable) {
 
         teamRepository.findById(teamId).orElseThrow(() ->
             new NotFoundException(ErrorCode.TEAM_NOT_FOUND));
 
-        return joinWaitingRepository.findAllByTeam_TeamIdAndStatus(teamId, status, pageable)
+        return joinWaitingRepository.findAllByTeam_TeamIdAndStatusAndIsMercenary(teamId, status,
+                isMercenary, pageable)
             .map(joinWaitingMapper::toJoinWaitingResponseDto);
     }
 
     @Transactional(readOnly = true)
     public Page<JoinWaitingResponseDto> findAllByApplicantIdAndStatusIn(Long applicantId,
-        Pageable pageable) {
+        boolean isMercenary, Pageable pageable) {
 
         profileRepository.findById(applicantId).orElseThrow(() ->
             new NotFoundException(ErrorCode.USER_NOT_FOUND));
@@ -193,8 +194,9 @@ public class JoinWaitingService {
         List<JoinWaitingStatus> targetStatuses = List.of(JoinWaitingStatus.PENDING,
             JoinWaitingStatus.REJECTED);
 
-        return joinWaitingRepository.findAllByApplicant_IdAndStatusIn(applicantId, targetStatuses,
-                pageable)
+        return joinWaitingRepository.findAllByApplicant_IdAndStatusInAndIsMercenary(applicantId,
+                targetStatuses,
+                isMercenary, pageable)
             .map(joinWaitingMapper::toJoinWaitingResponseDto);
     }
 

--- a/src/main/java/com/shootdoori/match/service/TeamService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamService.java
@@ -31,18 +31,20 @@ public class TeamService {
     private final TeamMapper teamMapper;
     private final MatchRequestService matchRequestService;
     private final MatchCreateService matchCreateService;
+    private final JoinWaitingService joinWaitingService;
 
 
     public TeamService(ProfileRepository profileRepository, TeamRepository teamRepository,
         TeamMemberService teamMemberService, TeamMapper teamMapper,
         MatchRequestService matchRequestService,
-        MatchCreateService matchCreateService) {
+        MatchCreateService matchCreateService, JoinWaitingService joinWaitingService) {
         this.profileRepository = profileRepository;
         this.teamRepository = teamRepository;
         this.teamMemberService = teamMemberService;
         this.teamMapper = teamMapper;
         this.matchRequestService = matchRequestService;
         this.matchCreateService = matchCreateService;
+        this.joinWaitingService = joinWaitingService;
     }
 
     public CreateTeamResponseDto create(TeamRequestDto requestDto, Long userId) {
@@ -98,6 +100,7 @@ public class TeamService {
         Team team = teamRepository.findByIdWithMembers(id).orElseThrow(() ->
             new NotFoundException(ErrorCode.TEAM_NOT_FOUND, String.valueOf(id)));
 
+        joinWaitingService.cancelAllPendingByTeam(id, "팀 삭제로 인한 자동 취소");
         cancelAllMatchesByTeamId(id);
 
         team.delete(userId);

--- a/src/main/java/com/shootdoori/match/value/TeamMembers.java
+++ b/src/main/java/com/shootdoori/match/value/TeamMembers.java
@@ -6,11 +6,9 @@ import com.shootdoori.match.exception.common.DuplicatedException;
 import com.shootdoori.match.exception.common.ErrorCode;
 import com.shootdoori.match.exception.domain.team.LastTeamMemberRemovalNotAllowedException;
 import com.shootdoori.match.exception.domain.team.TeamCapacityExceededException;
-import jakarta.persistence.AttributeOverride;
+import com.shootdoori.match.exception.domain.team.TeamHasRemainingMembersException;
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.Embedded;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +16,7 @@ import java.util.List;
 @Embeddable
 public class TeamMembers {
 
-    private static final int MIN_TEAM_MEMBERS = 1;
+    private static final int MIN_ACTIVE_MEMBERS = 1;
     private static final int MAX_TEAM_MEMBERS = 100;
 
     @OneToMany(
@@ -75,17 +73,18 @@ public class TeamMembers {
     }
 
     public void clear() {
+        ensureNoMembersRemaining();
         teamMembers.clear();
     }
 
     public void ensureNotFull() {
-        if (size() >= MAX_TEAM_MEMBERS) {
+        if (isFull()) {
             throw new TeamCapacityExceededException();
         }
     }
 
     private void ensureRemovable() {
-        if (size() <= MIN_TEAM_MEMBERS) {
+        if (isBelowMinActive()) {
             throw new LastTeamMemberRemovalNotAllowedException();
         }
     }
@@ -94,5 +93,23 @@ public class TeamMembers {
         if (teamMembers.stream().anyMatch(member -> member.isSameUser(targetUser))) {
             throw new DuplicatedException(ErrorCode.ALREADY_TEAM_MEMBER);
         }
+    }
+
+    private void ensureNoMembersRemaining() {
+        if (isRemaining()) {
+            throw new TeamHasRemainingMembersException();
+        }
+    }
+
+    private boolean isFull() {
+        return size() >= MAX_TEAM_MEMBERS;
+    }
+
+    private boolean isBelowMinActive() {
+        return size() <= MIN_ACTIVE_MEMBERS;
+    }
+
+    private boolean isRemaining() {
+        return size() > MIN_ACTIVE_MEMBERS;
     }
 }

--- a/src/test/java/com/shootdoori/joinWaiting/JoinWaitingServiceTest.java
+++ b/src/test/java/com/shootdoori/joinWaiting/JoinWaitingServiceTest.java
@@ -3,9 +3,7 @@ package com.shootdoori.joinWaiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -673,8 +671,8 @@ public class JoinWaitingServiceTest {
                 pageable, 2);
 
             when(teamRepository.findById(TEAM_ID)).thenReturn(Optional.of(team));
-            when(joinWaitingRepository.findAllByTeam_TeamIdAndStatus(TEAM_ID,
-                JoinWaitingStatus.PENDING, pageable))
+            when(joinWaitingRepository.findAllByTeam_TeamIdAndStatusAndIsMercenary(TEAM_ID,
+                JoinWaitingStatus.PENDING, false, pageable))
                 .thenReturn(joinWaitingPage);
 
             when(joinWaitingMapper.toJoinWaitingResponseDto(joinWaiting1)).thenReturn(responseDto1);
@@ -682,12 +680,42 @@ public class JoinWaitingServiceTest {
 
             // when
             Page<JoinWaitingResponseDto> resultDtoPage = joinWaitingService.findPending(
-                TEAM_ID, JoinWaitingStatus.PENDING, pageable
+                TEAM_ID, JoinWaitingStatus.PENDING, false, pageable
             );
 
             // then
             assertThat(resultDtoPage).hasSize(2);
             assertThat(resultDtoPage.getContent()).containsExactly(responseDto1, responseDto2);
+        }
+
+        @Test
+        @DisplayName("findPending - isMercenary 파라미터로 필터링")
+        void findPending_withIsMercenary_filters() {
+            // given
+            Pageable pageable = PageRequest.of(PAGE, SIZE, Sort.by("teamName").ascending());
+
+            JoinWaiting joinWaiting = JoinWaiting.create(team, applicant, "열심히 뛰겠습니다!", true);
+            JoinWaitingResponseDto responseDto = new JoinWaitingResponseDto(
+                1L, applicant.getName(), TEAM_ID, team.getTeamName().name(), applicant.getId(),
+                JoinWaitingStatus.PENDING.getDisplayName(), null,
+                null, null, true
+            );
+
+            Page<JoinWaiting> joinWaitingPage = new PageImpl<>(List.of(joinWaiting), pageable, 1);
+
+            when(teamRepository.findById(TEAM_ID)).thenReturn(Optional.of(team));
+            when(joinWaitingRepository.findAllByTeam_TeamIdAndStatusAndIsMercenary(TEAM_ID,
+                JoinWaitingStatus.PENDING, true, pageable)).thenReturn(joinWaitingPage);
+            when(joinWaitingMapper.toJoinWaitingResponseDto(joinWaiting)).thenReturn(responseDto);
+
+            // when
+            Page<JoinWaitingResponseDto> resultDtoPage = joinWaitingService.findPending(
+                TEAM_ID, JoinWaitingStatus.PENDING, true, pageable
+            );
+
+            // then
+            assertThat(resultDtoPage).hasSize(1);
+            assertThat(resultDtoPage.getContent()).containsExactly(responseDto);
         }
     }
 
@@ -738,14 +766,14 @@ public class JoinWaitingServiceTest {
             );
 
             when(profileRepository.findById(applicantId)).thenReturn(Optional.of(applicant));
-            when(joinWaitingRepository.findAllByApplicant_IdAndStatusIn(applicantId,
-                targetStatuses, pageRequest)).thenReturn(joinWaitingPage);
+            when(joinWaitingRepository.findAllByApplicant_IdAndStatusInAndIsMercenary(applicantId,
+                targetStatuses, false, pageRequest)).thenReturn(joinWaitingPage);
             when(joinWaitingMapper.toJoinWaitingResponseDto(joinWaiting1)).thenReturn(responseDto1);
             when(joinWaitingMapper.toJoinWaitingResponseDto(joinWaiting2)).thenReturn(responseDto2);
 
             // when
             Page<JoinWaitingResponseDto> resultDtoPage = joinWaitingService.findAllByApplicantIdAndStatusIn(
-                applicantId, pageRequest);
+                applicantId, false, pageRequest);
 
             // then
             assertThat(resultDtoPage).hasSize(2);
@@ -753,6 +781,38 @@ public class JoinWaitingServiceTest {
             assertThat(resultDtoPage.getTotalElements()).isEqualTo(2);
             assertThat(resultDtoPage.getContent().get(0).applicantId()).isEqualTo(applicantId);
             assertThat(resultDtoPage.getContent().get(1).applicantId()).isEqualTo(applicantId);
+        }
+
+        @Test
+        @DisplayName("findAllByApplicant_IdAndStatusIn - isMercenary 파라미터로 필터링")
+        void findAllByApplicant_IdAndStatusIn_filtersByMercenary() {
+            // given
+            Long applicantId = applicant.getId();
+            PageRequest pageRequest = PageRequest.of(PAGE, SIZE);
+
+            JoinWaiting mercenaryJoinWaiting = JoinWaiting.create(team, applicant, "용병 신청", true);
+            Page<JoinWaiting> joinWaitingPage = new PageImpl<>(List.of(mercenaryJoinWaiting),
+                pageRequest, 1);
+
+            JoinWaitingResponseDto responseDto = new JoinWaitingResponseDto(
+                1L, applicant.getName(), TEAM_ID, team.getTeamName().name(), applicantId,
+                JoinWaitingStatus.PENDING.getDisplayName(), null,
+                null, null, true
+            );
+
+            when(profileRepository.findById(applicantId)).thenReturn(Optional.of(applicant));
+            when(joinWaitingRepository.findAllByApplicant_IdAndStatusInAndIsMercenary(applicantId,
+                targetStatuses, true, pageRequest)).thenReturn(joinWaitingPage);
+            when(joinWaitingMapper.toJoinWaitingResponseDto(mercenaryJoinWaiting))
+                .thenReturn(responseDto);
+
+            // when
+            Page<JoinWaitingResponseDto> resultDtoPage = joinWaitingService
+                .findAllByApplicantIdAndStatusIn(applicantId, true, pageRequest);
+
+            // then
+            assertThat(resultDtoPage).hasSize(1);
+            assertThat(resultDtoPage.getContent()).containsExactly(responseDto);
         }
 
         @Test
@@ -767,7 +827,7 @@ public class JoinWaitingServiceTest {
             // when & then
             assertThatThrownBy(
                 () -> joinWaitingService.findAllByApplicantIdAndStatusIn(
-                    nonExistApplicantId, pageRequest))
+                    nonExistApplicantId, false, pageRequest))
                 .isInstanceOf(NotFoundException.class);
         }
 
@@ -780,13 +840,13 @@ public class JoinWaitingServiceTest {
             Page<JoinWaiting> emptyPage = new PageImpl<>(List.of(), pageRequest, 0);
 
             when(profileRepository.findById(applicantId)).thenReturn(Optional.of(applicant));
-            when(joinWaitingRepository.findAllByApplicant_IdAndStatusIn(applicantId, targetStatuses,
-                pageRequest)).thenReturn(
+            when(joinWaitingRepository.findAllByApplicant_IdAndStatusInAndIsMercenary(applicantId,
+                targetStatuses, false, pageRequest)).thenReturn(
                 emptyPage);
 
             // when
             Page<JoinWaitingResponseDto> resultDtoPage = joinWaitingService.findAllByApplicantIdAndStatusIn(
-                applicantId, pageRequest);
+                applicantId, false, pageRequest);
 
             // then
             assertThat(resultDtoPage).hasSize(0);

--- a/src/test/java/com/shootdoori/joinWaiting/JoinWaitingServiceTest.java
+++ b/src/test/java/com/shootdoori/joinWaiting/JoinWaitingServiceTest.java
@@ -3,8 +3,11 @@ package com.shootdoori.joinWaiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.shootdoori.match.dto.JoinWaitingApproveRequestDto;
@@ -591,6 +594,54 @@ public class JoinWaitingServiceTest {
                 eq(requestDto.decisionReason()),
                 eq(false)
             );
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelAllPendingByTeam 테스트")
+    class CancelAllPendingByTeamTest {
+
+        @Test
+        @DisplayName("모든 대기중 신청을 시스템이 취소하고 알림을 발송한다")
+        void cancelAllPendingByTeam_success() {
+            // given
+            String reason = "팀 삭제로 인한 자동 취소";
+            JoinWaiting pendingJoinWaiting = JoinWaiting.create(team, applicant, "가입요청", false);
+            JoinWaiting mercenaryJoinWaiting = JoinWaiting.create(team, anotherUser, "용병 신청", true);
+
+            when(joinWaitingRepository.findAllByTeam_TeamIdAndStatus(TEAM_ID,
+                JoinWaitingStatus.PENDING))
+                .thenReturn(List.of(pendingJoinWaiting, mercenaryJoinWaiting));
+
+            // when
+            joinWaitingService.cancelAllPendingByTeam(TEAM_ID, reason);
+
+            // then
+            assertThat(pendingJoinWaiting.getStatus()).isEqualTo(JoinWaitingStatus.CANCELED);
+            assertThat(pendingJoinWaiting.getDecisionReason()).isEqualTo(reason);
+            assertThat(pendingJoinWaiting.getDecidedBy()).isNull();
+            assertThat(pendingJoinWaiting.getDecidedAt()).isNotNull();
+
+            assertThat(mercenaryJoinWaiting.getStatus()).isEqualTo(JoinWaitingStatus.CANCELED);
+            assertThat(mercenaryJoinWaiting.getDecisionReason()).isEqualTo(reason);
+            assertThat(mercenaryJoinWaiting.getDecidedBy()).isNull();
+            assertThat(mercenaryJoinWaiting.getDecidedAt()).isNotNull();
+
+            verify(notificationService).sendJoinCancelNotification(
+                eq(team),
+                eq(applicant),
+                any(LocalDateTime.class),
+                eq(reason),
+                eq(false)
+            );
+            verify(notificationService).sendJoinCancelNotification(
+                eq(team),
+                eq(anotherUser),
+                any(LocalDateTime.class),
+                eq(reason),
+                eq(true)
+            );
+            verifyNoMoreInteractions(notificationService);
         }
     }
 

--- a/src/test/java/com/shootdoori/joinWaiting/JoinWaitingTest.java
+++ b/src/test/java/com/shootdoori/joinWaiting/JoinWaitingTest.java
@@ -3,10 +3,10 @@ package com.shootdoori.joinWaiting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.shootdoori.match.entity.common.SkillLevel;
 import com.shootdoori.match.entity.team.Team;
 import com.shootdoori.match.entity.team.TeamMember;
 import com.shootdoori.match.entity.team.TeamMemberRole;
-import com.shootdoori.match.entity.common.SkillLevel;
 import com.shootdoori.match.entity.team.TeamType;
 import com.shootdoori.match.entity.team.join.JoinWaiting;
 import com.shootdoori.match.entity.team.join.JoinWaitingStatus;
@@ -286,6 +286,39 @@ public class JoinWaitingTest {
                 .isInstanceOf(JoinWaitingNotPendingException.class);
 
             assertThat(joinWaiting.getStatus()).isEqualTo(JoinWaitingStatus.CANCELED);
+        }
+    }
+
+    @Nested
+    @DisplayName("시스템 취소 테스트")
+    class CancelBySystemTest {
+
+        @Test
+        @DisplayName("PENDING 상태의 신청을 시스템이 취소하면 상태와 메타데이터가 업데이트된다")
+        void cancelBySystem_whenPending_updatesStateAndMetadata() {
+            // given
+            JoinWaiting joinWaiting = JoinWaiting.create(team, applicant, "가입 요청입니다.", false);
+
+            // when
+            joinWaiting.cancelBySystem("팀 삭제로 인한 자동 취소");
+
+            // then
+            assertThat(joinWaiting.getStatus()).isEqualTo(JoinWaitingStatus.CANCELED);
+            assertThat(joinWaiting.getDecisionReason()).isEqualTo("팀 삭제로 인한 자동 취소");
+            assertThat(joinWaiting.getDecidedBy()).isNull();
+            assertThat(joinWaiting.getDecidedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("이미 처리된 신청에 시스템 취소를 호출하면 추가 변경이 발생하지 않는다")
+        void cancelBySystem_whenAlreadyProcessed_doesNothingOrThrows() {
+            // given
+            JoinWaiting joinWaiting = JoinWaiting.create(team, applicant, "가입 요청입니다.", false);
+            joinWaiting.reject(leaderMember, "이미 거절됨");
+
+            // when & then
+            joinWaiting.cancelBySystem("팀 삭제");
+            assertThat(joinWaiting.getStatus()).isEqualTo(JoinWaitingStatus.REJECTED);
         }
     }
 }

--- a/src/test/java/com/shootdoori/team/TeamServiceTest.java
+++ b/src/test/java/com/shootdoori/team/TeamServiceTest.java
@@ -10,13 +10,14 @@ import com.shootdoori.match.dto.CreateTeamResponseDto;
 import com.shootdoori.match.dto.TeamDetailResponseDto;
 import com.shootdoori.match.dto.TeamMapper;
 import com.shootdoori.match.dto.TeamRequestDto;
-import com.shootdoori.match.entity.team.Team;
 import com.shootdoori.match.entity.common.SkillLevel;
+import com.shootdoori.match.entity.team.Team;
 import com.shootdoori.match.entity.team.TeamType;
 import com.shootdoori.match.entity.user.User;
 import com.shootdoori.match.exception.common.NotFoundException;
 import com.shootdoori.match.repository.ProfileRepository;
 import com.shootdoori.match.repository.TeamRepository;
+import com.shootdoori.match.service.JoinWaitingService;
 import com.shootdoori.match.service.MatchCreateService;
 import com.shootdoori.match.service.MatchRequestService;
 import com.shootdoori.match.service.TeamMemberService;
@@ -69,6 +70,9 @@ public class TeamServiceTest {
     @Mock
     private MatchCreateService matchCreateService;
 
+    @Mock
+    private JoinWaitingService joinWaitingService;
+
     private TeamService teamService;
     private TeamRequestDto requestDto;
     private User captain;
@@ -77,7 +81,7 @@ public class TeamServiceTest {
     @BeforeEach
     void setUp() {
         teamService = new TeamService(profileRepository, teamRepository, teamMemberService,
-            teamMapper, matchRequestService, matchCreateService);
+            teamMapper, matchRequestService, matchCreateService, joinWaitingService);
 
         requestDto = new TeamRequestDto(
             "강원대 FC",
@@ -368,13 +372,15 @@ public class TeamServiceTest {
 
             // then
             verify(teamRepository).save(existingTeam);
+            verify(joinWaitingService).cancelAllPendingByTeam(TEAM_ID, "팀 삭제로 인한 자동 취소");
         }
 
         @Test
         @DisplayName("팀 없음 예외")
         void delete_notFound_throws() {
             // given
-            when(teamRepository.findByIdWithMembers(NON_EXISTENT_TEAM_ID)).thenReturn(Optional.empty());
+            when(teamRepository.findByIdWithMembers(NON_EXISTENT_TEAM_ID)).thenReturn(
+                Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> teamService.delete(NON_EXISTENT_TEAM_ID, captain.getId()))
@@ -441,6 +447,8 @@ public class TeamServiceTest {
                 NotFoundException.class);
         }
     }
+
+
 
     private Team createTeam(String name, TeamType teamType, SkillLevel skillLevel,
         String description) {

--- a/src/test/java/com/shootdoori/team/TeamTest.java
+++ b/src/test/java/com/shootdoori/team/TeamTest.java
@@ -2,6 +2,7 @@ package com.shootdoori.team;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import com.shootdoori.match.entity.common.SkillLevel;
 import com.shootdoori.match.entity.team.Team;
@@ -14,6 +15,7 @@ import com.shootdoori.match.exception.common.DuplicatedException;
 import com.shootdoori.match.exception.common.NoPermissionException;
 import com.shootdoori.match.exception.domain.team.LastTeamMemberRemovalNotAllowedException;
 import com.shootdoori.match.exception.domain.team.TeamCapacityExceededException;
+import com.shootdoori.match.exception.domain.team.TeamHasRemainingMembersException;
 import com.shootdoori.match.value.TeamMembers;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("Team 도메인 모델 테스트")
@@ -317,6 +320,22 @@ public class TeamTest {
                 .isInstanceOf(DuplicatedException.class);
         }
 
+        @Test
+        @DisplayName("멤버 수가 2명일 때 삭제 시 예외 발생")
+        void deleteTeam_whenRemainingMembers_throws() {
+            //given
+            TeamMembers embedded = TeamMembers.empty();
+            List<TeamMember> teamMembers = new ArrayList<>();
+            teamMembers.add(mock(TeamMember.class));
+            teamMembers.add(mock(TeamMember.class));
+
+            ReflectionTestUtils.setField(embedded, "teamMembers", teamMembers);
+            ReflectionTestUtils.setField(team, "teamMembers", embedded);
+
+            // when & then
+            assertThatThrownBy(() -> team.delete(captainId))
+                .isInstanceOf(TeamHasRemainingMembersException.class);
+        }
     }
 
     @Nested


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지
- fix(team): 남은 멤버가 있을 때, 회장이 팀 삭제 불가하도록 수정
  - 팀 삭제 시 멤버 수 검증 강화
- test(team): 멤버 수가 2명 이상일 때 팀 삭제 시 예외 발생 단위 테스트 추가
  - 팀 삭제 제약 조건에 대한 동작 보장
- refactor: 팀 삭제 시 가입 대기 요청 자동 취소 로직 추가
  - cancelAllPendingByTeam 도입
  - 대기 상태(PENDING)만 시스템 취소, 알림 발송
- test: cancelAllPendingByTeam·cancelBySystem 시나리오 검증 추가
- feat: 용병 여부로 팀/사용자 가입 대기 조회
  - 조회 API에 isMercenary 플래그 반영

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
❌ 

---

*PR 확인 부탁드려요! 🙏*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering for pending team join requests by mercenary status

* **Bug Fixes**
  * Teams can no longer be deleted while active members remain assigned
  * Pending join applications automatically cancel when teams are deleted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->