### PR TITLE
refactor: 팀 삭제 시, 해당 팀이 작성한 용병 게시글도 모두 삭제되도록 수정

### DIFF
--- a/src/main/java/com/shootdoori/match/entity/team/Team.java
+++ b/src/main/java/com/shootdoori/match/entity/team/Team.java
@@ -144,6 +144,8 @@ public class Team {
         return captain.equals(user);
     }
 
+    public boolean isCaptainId(Long userId) { return Objects.equals(getCaptain().getId(), userId); }
+
     public boolean isDeleted() {
         return softDelete.isDeleted();
     }
@@ -191,7 +193,7 @@ public class Team {
     }
 
     public void delete(Long userId) {
-        if (!Objects.equals(getCaptain().getId(), userId)) {
+        if (!isCaptainId(userId)) {
             throw new NoPermissionException(ErrorCode.CAPTAIN_ONLY_OPERATION);
         }
 
@@ -200,14 +202,13 @@ public class Team {
     }
 
     public void restore(Long userId) {
-        if (!Objects.equals(getCaptain().getId(), userId)) {
+        if (!isCaptainId(userId)) {
             throw new NoPermissionException(ErrorCode.CAPTAIN_ONLY_OPERATION);
         }
 
         addMember(captain, TeamMemberRole.LEADER);
         softDelete.changeStatusActive();
     }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/com/shootdoori/match/repository/MercenaryRecruitmentRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/MercenaryRecruitmentRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MercenaryRecruitmentRepository extends JpaRepository<MercenaryRecruitment, Long> {
     Page<MercenaryRecruitment> findByTeam_Captain_Id(Long userId, Pageable pageable);
+
+    void deleteAllByTeam_TeamId(Long teamId);
 }

--- a/src/main/java/com/shootdoori/match/repository/TeamRepository.java
+++ b/src/main/java/com/shootdoori/match/repository/TeamRepository.java
@@ -11,10 +11,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
-
-    @EntityGraph(attributePaths = {"teamMembers.teamMembers"})
+    @EntityGraph(attributePaths = {"teamMembers.members"})
     @Query("SELECT t FROM Team t WHERE t.teamId = :teamId")
-    Optional<Team> findByIdWithMembers(@Param("teamId") Long teamId);
+    Optional<Team> findByIdWithAssociations(@Param("teamId") Long teamId);
 
     Page<Team> findAllByUniversity(UniversityName university, Pageable pageable);
 

--- a/src/main/java/com/shootdoori/match/service/MercenaryRecruitmentService.java
+++ b/src/main/java/com/shootdoori/match/service/MercenaryRecruitmentService.java
@@ -21,14 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 public class MercenaryRecruitmentService {
-    private final TeamService teamService;
-    private final ProfileService profileService;
+
     private final MercenaryRecruitmentRepository recruitmentRepository;
     private final TeamRepository teamRepository;
 
-    public MercenaryRecruitmentService(TeamService teamService, ProfileService profileService, MercenaryRecruitmentRepository recruitmentRepository, TeamRepository teamRepository) {
-        this.teamService = teamService;
-        this.profileService = profileService;
+    public MercenaryRecruitmentService(MercenaryRecruitmentRepository recruitmentRepository,
+        TeamRepository teamRepository) {
         this.recruitmentRepository = recruitmentRepository;
         this.teamRepository = teamRepository;
     }
@@ -36,17 +34,20 @@ public class MercenaryRecruitmentService {
     public RecruitmentResponse create(RecruitmentCreateRequest request, Long loginUserId) {
 
         Team team = teamRepository.findById(request.teamId()).orElseThrow(
-            () -> new NotFoundException(ErrorCode.TEAM_NOT_FOUND, String.valueOf(request.teamId())));
+            () -> new NotFoundException(ErrorCode.TEAM_NOT_FOUND,
+                String.valueOf(request.teamId())));
 
-        if(!team.getCaptain().getId().equals(loginUserId)) {
+        if (!team.isCaptainId(loginUserId)) {
             throw new NoPermissionException();
         }
 
         Position position = Position.fromCode(request.position());
         SkillLevel skillLevel = SkillLevel.fromDisplayName(request.skillLevel());
 
-        MercenaryRecruitment savedRecruitment = recruitmentRepository.save(MercenaryRecruitment.create(
-            team, request.matchDate(), request.matchTime(), request.message(), position, skillLevel));
+        MercenaryRecruitment savedRecruitment = recruitmentRepository.save(
+            MercenaryRecruitment.create(
+                team, request.matchDate(), request.matchTime(), request.message(), position,
+                skillLevel));
 
         return RecruitmentResponse.from(savedRecruitment);
     }
@@ -60,7 +61,8 @@ public class MercenaryRecruitmentService {
 
     @Transactional(readOnly = true)
     public Page<RecruitmentResponse> findAllForCaptain(Pageable pageable, Long loginUserId) {
-        Page<MercenaryRecruitment> recruitments = recruitmentRepository.findByTeam_Captain_Id(loginUserId, pageable);
+        Page<MercenaryRecruitment> recruitments = recruitmentRepository.findByTeam_Captain_Id(
+            loginUserId, pageable);
 
         return recruitments.map(RecruitmentResponse::from);
     }
@@ -75,15 +77,17 @@ public class MercenaryRecruitmentService {
 
     @Transactional(readOnly = true)
     public MercenaryRecruitment findByIdForEntity(Long id) {
-        return recruitmentRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.RECRUITMENT_NOT_FOUND));
+        return recruitmentRepository.findById(id)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.RECRUITMENT_NOT_FOUND));
     }
 
-    public RecruitmentResponse update(Long id, RecruitmentUpdateRequest updateRequest, Long loginUserId) {
+    public RecruitmentResponse update(Long id, RecruitmentUpdateRequest updateRequest,
+        Long loginUserId) {
 
         MercenaryRecruitment recruitment = recruitmentRepository.findById(id)
             .orElseThrow(() -> new NotFoundException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
-        if(!recruitment.getTeam().getCaptain().getId().equals(loginUserId)) {
+        if (!recruitment.getTeam().getCaptain().getId().equals(loginUserId)) {
             throw new NoPermissionException();
         }
 
@@ -91,20 +95,26 @@ public class MercenaryRecruitmentService {
         SkillLevel skillLevel = SkillLevel.fromDisplayName(updateRequest.skillLevel());
 
         recruitment.updateRecruitmentInfo(
-            updateRequest.matchDate(), updateRequest.matchTime(), updateRequest.message(), position, skillLevel);
+            updateRequest.matchDate(), updateRequest.matchTime(), updateRequest.message(), position,
+            skillLevel);
 
         return RecruitmentResponse.from(recruitment);
     }
 
     public void delete(Long id, Long loginUserId) {
 
-        MercenaryRecruitment recruitment = recruitmentRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.RECRUITMENT_NOT_FOUND));
+        MercenaryRecruitment recruitment = recruitmentRepository.findById(id)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.RECRUITMENT_NOT_FOUND));
 
-        if(!recruitment.getTeam().getCaptain().getId().equals(loginUserId)) {
+        if (!recruitment.getTeam().getCaptain().getId().equals(loginUserId)) {
             throw new NoPermissionException();
         }
 
         recruitmentRepository.deleteById(id);
+    }
+
+    public void deleteAllByTeamId(Long teamId) {
+        recruitmentRepository.deleteAllByTeam_TeamId(teamId);
     }
 
     private void validateCaptain(Team team, User user) {

--- a/src/main/java/com/shootdoori/match/service/TeamService.java
+++ b/src/main/java/com/shootdoori/match/service/TeamService.java
@@ -29,6 +29,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final TeamMemberService teamMemberService;
     private final TeamMapper teamMapper;
+    private final MercenaryRecruitmentService mercenaryRecruitmentService;
     private final MatchRequestService matchRequestService;
     private final MatchCreateService matchCreateService;
     private final JoinWaitingService joinWaitingService;
@@ -36,12 +37,14 @@ public class TeamService {
 
     public TeamService(ProfileRepository profileRepository, TeamRepository teamRepository,
         TeamMemberService teamMemberService, TeamMapper teamMapper,
+        MercenaryRecruitmentService mercenaryRecruitmentService,
         MatchRequestService matchRequestService,
         MatchCreateService matchCreateService, JoinWaitingService joinWaitingService) {
         this.profileRepository = profileRepository;
         this.teamRepository = teamRepository;
         this.teamMemberService = teamMemberService;
         this.teamMapper = teamMapper;
+        this.mercenaryRecruitmentService = mercenaryRecruitmentService;
         this.matchRequestService = matchRequestService;
         this.matchCreateService = matchCreateService;
         this.joinWaitingService = joinWaitingService;
@@ -97,9 +100,10 @@ public class TeamService {
     }
 
     public void delete(Long id, Long userId) {
-        Team team = teamRepository.findByIdWithMembers(id).orElseThrow(() ->
+        Team team = teamRepository.findByIdWithAssociations(id).orElseThrow(() ->
             new NotFoundException(ErrorCode.TEAM_NOT_FOUND, String.valueOf(id)));
 
+        mercenaryRecruitmentService.deleteAllByTeamId(team.getTeamId());
         joinWaitingService.cancelAllPendingAndRejectedByTeam(id, "팀 삭제로 인한 자동 취소");
         cancelAllMatchesByTeamId(id);
 

--- a/src/main/java/com/shootdoori/match/value/TeamMembers.java
+++ b/src/main/java/com/shootdoori/match/value/TeamMembers.java
@@ -24,19 +24,19 @@ public class TeamMembers {
         cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
         orphanRemoval = true
     )
-    private List<TeamMember> teamMembers = new ArrayList<>();
+    private List<TeamMember> members = new ArrayList<>();
 
     protected TeamMembers() {
     }
 
-    public TeamMembers(List<TeamMember> teamMembers) {
-        this.teamMembers = teamMembers == null
+    public TeamMembers(List<TeamMember> members) {
+        this.members = members == null
             ? new ArrayList<>()
-            : new ArrayList<>(teamMembers);
+            : new ArrayList<>(members);
     }
 
     public List<TeamMember> getTeamMembers() {
-        return teamMembers;
+        return members;
     }
 
     public static TeamMembers empty() {
@@ -44,19 +44,19 @@ public class TeamMembers {
     }
 
     public int size() {
-        return teamMembers.size();
+        return members.size();
     }
 
     public boolean isEmpty() {
-        return teamMembers.isEmpty();
+        return members.isEmpty();
     }
 
     public boolean hasCaptain() {
-        return teamMembers.stream().anyMatch(TeamMember::isCaptain);
+        return members.stream().anyMatch(TeamMember::isCaptain);
     }
 
     public boolean hasViceCaptain() {
-        return teamMembers.stream().anyMatch(TeamMember::isViceCaptain);
+        return members.stream().anyMatch(TeamMember::isViceCaptain);
     }
 
     public void addMember(TeamMember targetMember) {
@@ -64,17 +64,17 @@ public class TeamMembers {
 
         ensureNotFull();
         ensureNotMember(targetUser);
-        teamMembers.add(targetMember);
+        members.add(targetMember);
     }
 
     public void removeMember(TeamMember targetMember) {
         ensureRemovable();
-        teamMembers.remove(targetMember);
+        members.remove(targetMember);
     }
 
     public void clear() {
         ensureNoMembersRemaining();
-        teamMembers.clear();
+        members.clear();
     }
 
     public void ensureNotFull() {
@@ -90,7 +90,7 @@ public class TeamMembers {
     }
 
     private void ensureNotMember(User targetUser) {
-        if (teamMembers.stream().anyMatch(member -> member.isSameUser(targetUser))) {
+        if (members.stream().anyMatch(member -> member.isSameUser(targetUser))) {
             throw new DuplicatedException(ErrorCode.ALREADY_TEAM_MEMBER);
         }
     }

--- a/src/test/java/com/shootdoori/team/TeamServiceTest.java
+++ b/src/test/java/com/shootdoori/team/TeamServiceTest.java
@@ -20,6 +20,7 @@ import com.shootdoori.match.repository.TeamRepository;
 import com.shootdoori.match.service.JoinWaitingService;
 import com.shootdoori.match.service.MatchCreateService;
 import com.shootdoori.match.service.MatchRequestService;
+import com.shootdoori.match.service.MercenaryRecruitmentService;
 import com.shootdoori.match.service.TeamMemberService;
 import com.shootdoori.match.service.TeamService;
 import com.shootdoori.match.value.UniversityName;
@@ -65,6 +66,9 @@ public class TeamServiceTest {
     private TeamMemberService teamMemberService;
 
     @Mock
+    private MercenaryRecruitmentService mercenaryRecruitmentService;
+
+    @Mock
     private MatchRequestService matchRequestService;
 
     @Mock
@@ -81,7 +85,8 @@ public class TeamServiceTest {
     @BeforeEach
     void setUp() {
         teamService = new TeamService(profileRepository, teamRepository, teamMemberService,
-            teamMapper, matchRequestService, matchCreateService, joinWaitingService);
+            teamMapper, mercenaryRecruitmentService, matchRequestService, matchCreateService,
+            joinWaitingService);
 
         requestDto = new TeamRequestDto(
             "강원대 FC",
@@ -365,7 +370,8 @@ public class TeamServiceTest {
                 "삭제될 팀입니다."
             );
 
-            when(teamRepository.findByIdWithMembers(TEAM_ID)).thenReturn(Optional.of(existingTeam));
+            when(teamRepository.findByIdWithAssociations(TEAM_ID)).thenReturn(
+                Optional.of(existingTeam));
 
             // when
             teamService.delete(TEAM_ID, captain.getId());
@@ -379,7 +385,7 @@ public class TeamServiceTest {
         @DisplayName("팀 없음 예외")
         void delete_notFound_throws() {
             // given
-            when(teamRepository.findByIdWithMembers(NON_EXISTENT_TEAM_ID)).thenReturn(
+            when(teamRepository.findByIdWithAssociations(NON_EXISTENT_TEAM_ID)).thenReturn(
                 Optional.empty());
 
             // when & then
@@ -403,7 +409,8 @@ public class TeamServiceTest {
                 "삭제될 팀입니다."
             );
 
-            when(teamRepository.findByIdWithMembers(TEAM_ID)).thenReturn(Optional.of(existingTeam));
+            when(teamRepository.findByIdWithAssociations(TEAM_ID)).thenReturn(
+                Optional.of(existingTeam));
 
             teamService.delete(TEAM_ID, captain.getId());
         }
@@ -447,7 +454,6 @@ public class TeamServiceTest {
                 NotFoundException.class);
         }
     }
-
 
 
     private Team createTeam(String name, TeamType teamType, SkillLevel skillLevel,

--- a/src/test/java/com/shootdoori/team/TeamTest.java
+++ b/src/test/java/com/shootdoori/team/TeamTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("Team 도메인 모델 테스트")
@@ -239,7 +238,7 @@ public class TeamTest {
                     TeamMemberRole.MEMBER
                 ));
             }
-            ReflectionTestUtils.setField(teamMembers, "teamMembers", members);
+            ReflectionTestUtils.setField(teamMembers, "members", members);
 
             // when & then
             assertThatThrownBy(() ->
@@ -329,7 +328,7 @@ public class TeamTest {
             teamMembers.add(mock(TeamMember.class));
             teamMembers.add(mock(TeamMember.class));
 
-            ReflectionTestUtils.setField(embedded, "teamMembers", teamMembers);
+            ReflectionTestUtils.setField(embedded, "members", teamMembers);
             ReflectionTestUtils.setField(team, "teamMembers", embedded);
 
             // when & then


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
❌ 

---

## 🛠️ 뭘 했는지
- 팀 삭제 시, 해당 팀이 작성한 용병 게시글도 모두 삭제되도록 수정

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
❌ 
---

*PR 확인 부탁드려요! 🙏*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to manage mercenary recruitment records when deleting teams, ensuring associated recruitment data is properly cleaned up.

* **Bug Fixes**
  * Improved team deletion flow to handle all related data dependencies more reliably.

* **Tests**
  * Updated test suite to reflect refactored team management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->